### PR TITLE
Fix not building locally due to VersionSuffix missing

### DIFF
--- a/LambdaS3FileZipper/LambdaS3FileZipper.csproj
+++ b/LambdaS3FileZipper/LambdaS3FileZipper.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/litmus/aws-lambda-s3-zipper-dotnet</RepositoryUrl>
     <AssemblyVersion>1.0.1.0</AssemblyVersion>
     <FileVersion>1.0.1.0</FileVersion>
-    <Version>1.0.1.$(VersionSuffix)</Version>
+    <Version Condition="'$(VersionSuffix)' != ''">1.0.1.$(VersionSuffix)</Version>
     <DefineConstants>LIBLOG_PORTABLE</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
Local build is breaking with the error 
`error : '1.0.1.' is not a valid version string.`

This PR will resolve that