### PR TITLE
Make empty constructors for models

### DIFF
--- a/LambdaS3FileZipper/Models/Request.cs
+++ b/LambdaS3FileZipper/Models/Request.cs
@@ -2,6 +2,12 @@ namespace LambdaS3FileZipper.Models
 {
 	public class Request
 	{
+        // Empty constructor required for serialization
+        public Request()
+        {
+
+        }
+
 		public Request(
 			string originBucketName,
 			string originResourceName,

--- a/LambdaS3FileZipper/Models/Response.cs
+++ b/LambdaS3FileZipper/Models/Response.cs
@@ -2,6 +2,12 @@ namespace LambdaS3FileZipper.Models
 {
 	public class Response
 	{
+        // Empty constructor needed for seriliazation 
+        public Response()
+        {
+
+        }
+
 		public Response(string url)
 		{
 			Url = url;


### PR DESCRIPTION
In order to serialize our models, we will need default empty constructors