### PR TITLE
Verify origin bucket:resource param actually lists files

### DIFF
--- a/LambdaS3FileZipper/Aws/S3FileRetriever.cs
+++ b/LambdaS3FileZipper/Aws/S3FileRetriever.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using LambdaS3FileZipper.Exceptions;
 using LambdaS3FileZipper.Interfaces;
 using LambdaS3FileZipper.Logging;
 
@@ -29,7 +29,7 @@ namespace LambdaS3FileZipper.Aws
 			if (files.Any() == false)
 			{
 				log.Warn("There are no files listed under {bucket}:{resource}; nothing to ZIP", bucket, resource);
-				throw new ArgumentException($"There are no files listed under {bucket}:{resource}; nothing to ZIP");
+				throw new ResourceNotFoundException(bucket, resource);
 			}
 
 			var downloadPath = Path.Combine(Path.GetTempPath(), bucket);

--- a/LambdaS3FileZipper/Aws/S3FileRetriever.cs
+++ b/LambdaS3FileZipper/Aws/S3FileRetriever.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.Interfaces;
+using LambdaS3FileZipper.Logging;
 
 namespace LambdaS3FileZipper.Aws
 {
@@ -11,15 +14,23 @@ namespace LambdaS3FileZipper.Aws
 		private const int MaxConcurrentDownloads = 10;
 
 		private readonly IAwsS3Client s3Client;
+		private readonly ILog log;
 
 		public S3FileRetriever(IAwsS3Client s3Client)
 		{
 			this.s3Client = s3Client;
+
+			this.log = LogProvider.GetCurrentClassLogger();
 		}
 
 		public async Task<string> Retrieve(string bucket, string resource, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			var files = await s3Client.List(bucket, resource, cancellationToken);
+			if (files.Any() == false)
+			{
+				log.Warn("There are no files listed under {bucket}:{resource}; nothing to ZIP", bucket, resource);
+				throw new ArgumentException($"There are no files listed under {bucket}:{resource}; nothing to ZIP");
+			}
 
 			var downloadPath = Path.Combine(Path.GetTempPath(), bucket);
 

--- a/LambdaS3FileZipper/Exceptions/ResourceNotFoundException.cs
+++ b/LambdaS3FileZipper/Exceptions/ResourceNotFoundException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace LambdaS3FileZipper.Exceptions
+{
+    public class ResourceNotFoundException : ArgumentException
+    {
+        public ResourceNotFoundException(string bucket, string resource) : base($"No files found under {bucket}:{resource}")
+        {
+        }
+    }
+}

--- a/LambdaS3FileZipper/Service.cs
+++ b/LambdaS3FileZipper/Service.cs
@@ -24,7 +24,8 @@ namespace LambdaS3FileZipper
 	    public async Task<Response> Process(Request request, CancellationToken cancellationToken = default(CancellationToken))
 	    {
 		    var directory = await fileRetriever.Retrieve(request.OriginBucketName, request.OriginResourceName, cancellationToken);
-		    log.Debug("Retrieved files from {Bucket}:{Resource}", request.OriginBucketName, request.OriginResourceName);
+		    log.Debug("Retrieved files from {Bucket}:{Resource} into directory {Directory}",
+		        request.OriginBucketName, request.OriginResourceName, directory);
 
 		    var compressedFileName = await fileZipper.Compress(directory, flat: request.FlatZipFile);
 		    log.Debug("Compressed file to {CompressedFileName}", compressedFileName);


### PR DESCRIPTION
While debugging this **missing directory** error,

```
 "errorType": "IOException",
    "errorMessage": "/tmp/staging does not exist",
    "stackTrace": [
      "at LambdaS3FileZipper.FileZipper.<Compress>d__0.MoveNext()",
      "at LambdaS3FileZipper.Service.<Process>d__5.MoveNext()",
      "at LambdaS3FileZipper.Handler.<Handle>d__4.MoveNext()",
    ]
  },
```

I discovered the origin `bucket`:`resource` param listed **no files**, which would silently skip download and try to compress the non-existing directory. Fixed it by verifying origin `bucket`:`resource` param actually has files before attempting to download. _Also_ adds more logging around file retrieval.