### PR TITLE
Support filtering files by RegEx expression

### DIFF
--- a/LambdaS3FileZipper.IntegrationTests/Aws/S3FileRetrieverFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/S3FileRetrieverFixture.cs
@@ -19,7 +19,7 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 		[Test]
 		public async Task Retrieve_ShouldDownloadAllFiles()
 		{
-			var directory = await fileRetriever.Retrieve(TestEnvironment.IntegrationTestBucket, "", CancellationToken.None);
+			var directory = await fileRetriever.Retrieve(TestEnvironment.IntegrationTestBucket, "test.png", resourceExpressionPattern: ".*");
 
 			Assert.IsTrue(Directory.Exists(directory));
 

--- a/LambdaS3FileZipper.IntegrationTests/HandlerFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/HandlerFixture.cs
@@ -34,6 +34,7 @@ namespace LambdaS3FileZipper.IntegrationTests
 				OriginResourceName = TestEnvironment.OriginTestResourceName,
 				DestinationBucketName = TestEnvironment.DestinationTestBucket,
 				DestinationResourceName = "integration-test.zip",
+                OriginResourceExpressionPattern = @".",
 				FlatZipFile = true
 			};
 

--- a/LambdaS3FileZipper.IntegrationTests/LambdaS3FileZipper.IntegrationTests.csproj
+++ b/LambdaS3FileZipper.IntegrationTests/LambdaS3FileZipper.IntegrationTests.csproj
@@ -4,6 +4,8 @@
 		<TargetFramework>netcoreapp2.0</TargetFramework>
 
 		<IsPackable>false</IsPackable>
+
+		<LangVersion>7.1</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/LambdaS3FileZipper.Test/LambdaS3FileZipper.Test.csproj
+++ b/LambdaS3FileZipper.Test/LambdaS3FileZipper.Test.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LambdaS3FileZipper.Test/ServiceFixture.cs
+++ b/LambdaS3FileZipper.Test/ServiceFixture.cs
@@ -1,7 +1,5 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Amazon.Lambda.Core;
 using LambdaS3FileZipper.Interfaces;
 using LambdaS3FileZipper.Models;
 using NSubstitute;
@@ -33,7 +31,7 @@ namespace LambdaS3FileZipper.Test
 			url = "s3.com/compressed-file";
 
 			fileRetriever = Substitute.For<IFileRetriever>();
-			fileRetriever.Retrieve(request.OriginBucketName, request.OriginResourceName, Arg.Any<CancellationToken>()).Returns(directory);
+			fileRetriever.Retrieve(request.OriginBucketName, request.OriginResourceName, Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(directory);
 
 			fileZipper = Substitute.For<IFileZipper>();
 			fileZipper.Compress(directory, Arg.Any<bool>()).Returns(compressedFile);
@@ -57,7 +55,7 @@ namespace LambdaS3FileZipper.Test
 		{
 			await service.Process(request);
 
-			await fileRetriever.Received().Retrieve(request.OriginBucketName, request.OriginResourceName, Arg.Any<CancellationToken>());
+			await fileRetriever.Received().Retrieve(request.OriginBucketName, request.OriginResourceName);
 		}
 
 		[Test]

--- a/LambdaS3FileZipper/Aws/AwsS3Client.cs
+++ b/LambdaS3FileZipper/Aws/AwsS3Client.cs
@@ -25,7 +25,7 @@ namespace LambdaS3FileZipper.Aws
 			var request = new ListObjectsV2Request
 			{
 				BucketName = bucketName,
-				Prefix = resource
+				Prefix = resource,
 			};
 
 			ListObjectsV2Response response;

--- a/LambdaS3FileZipper/Aws/S3FileRetriever.cs
+++ b/LambdaS3FileZipper/Aws/S3FileRetriever.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.Exceptions;
@@ -12,8 +13,9 @@ namespace LambdaS3FileZipper.Aws
 	public class S3FileRetriever : IFileRetriever
 	{
 		private const int MaxConcurrentDownloads = 10;
+	    private const string DefaultResourceExpressionPattern = ".*";
 
-		private readonly IAwsS3Client s3Client;
+        private readonly IAwsS3Client s3Client;
 		private readonly ILog log;
 
 		public S3FileRetriever(IAwsS3Client s3Client)
@@ -23,17 +25,28 @@ namespace LambdaS3FileZipper.Aws
 			this.log = LogProvider.GetCurrentClassLogger();
 		}
 
-		public async Task<string> Retrieve(string bucket, string resource, CancellationToken cancellationToken = default(CancellationToken))
+		public async Task<string> Retrieve(
+		    string bucket,
+		    string resource,
+            string resourceExpressionPattern = default,
+		    CancellationToken cancellationToken = default)
 		{
-			var files = await s3Client.List(bucket, resource, cancellationToken);
-			if (files.Any() == false)
+		    if (string.IsNullOrWhiteSpace(resourceExpressionPattern))
+		    {
+		        resourceExpressionPattern = DefaultResourceExpressionPattern;
+            }
+
+            log.Debug("Using resource name expression pattern {resourceExpressionPattern}", resourceExpressionPattern);
+		    var regex = new Regex(resourceExpressionPattern, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            var files = (await s3Client.List(bucket, resource, cancellationToken)).Where(file => regex.IsMatch(file)).ToArray();
+		    if (files.Any() == false)
 			{
-				log.Warn("There are no files listed under {bucket}:{resource}; nothing to ZIP", bucket, resource);
-				throw new ResourceNotFoundException(bucket, resource);
+				log.Warn("There are no files listed under {bucket}/{resource} that match expression {resourceExpressionPattern}; nothing to ZIP",
+				    bucket, resource, resourceExpressionPattern);
+				throw new ResourceNotFoundException(bucket, resource, resourceExpressionPattern);
 			}
 
 			var downloadPath = Path.Combine(Path.GetTempPath(), bucket);
-
 			if (Directory.Exists(downloadPath))
 			{
 				Directory.Delete(downloadPath, recursive: true);

--- a/LambdaS3FileZipper/Exceptions/ResourceNotFoundException.cs
+++ b/LambdaS3FileZipper/Exceptions/ResourceNotFoundException.cs
@@ -5,8 +5,15 @@ namespace LambdaS3FileZipper.Exceptions
     public class ResourceNotFoundException : ArgumentException
     {
         public ResourceNotFoundException(string bucket, string resource, string resourceExpressionPattern)
-            : base($"No files found for resource `{bucket}/{resource}` that match expression `{resourceExpressionPattern}`")
+            : base("No files found for given bucket/resource that match the expression")
         {
+            Bucket = bucket;
+            Resource = resource;
+            ResourceExpressionPattern = resourceExpressionPattern;
         }
+
+        public string Bucket { get; set; }
+        public string Resource { get; set; }
+        public string ResourceExpressionPattern { get; set; }
     }
 }

--- a/LambdaS3FileZipper/Exceptions/ResourceNotFoundException.cs
+++ b/LambdaS3FileZipper/Exceptions/ResourceNotFoundException.cs
@@ -4,7 +4,8 @@ namespace LambdaS3FileZipper.Exceptions
 {
     public class ResourceNotFoundException : ArgumentException
     {
-        public ResourceNotFoundException(string bucket, string resource) : base($"No files found under {bucket}:{resource}")
+        public ResourceNotFoundException(string bucket, string resource, string resourceExpressionPattern)
+            : base($"No files found for resource `{bucket}/{resource}` that match expression `{resourceExpressionPattern}`")
         {
         }
     }

--- a/LambdaS3FileZipper/Interfaces/IFileRetriever.cs
+++ b/LambdaS3FileZipper/Interfaces/IFileRetriever.cs
@@ -5,6 +5,6 @@ namespace LambdaS3FileZipper.Interfaces
 {
 	public interface IFileRetriever
 	{
-		Task<string> Retrieve(string bucket, string resource, CancellationToken cancellationToken);
+		Task<string> Retrieve(string bucket, string resource, string resourceExpressionPattern = null, CancellationToken cancellationToken = default);
 	}
 }

--- a/LambdaS3FileZipper/LambdaS3FileZipper.csproj
+++ b/LambdaS3FileZipper/LambdaS3FileZipper.csproj
@@ -12,6 +12,7 @@
     <FileVersion>1.0.1.0</FileVersion>
     <Version Condition="'$(VersionSuffix)' != ''">1.0.1.$(VersionSuffix)</Version>
     <DefineConstants>LIBLOG_PORTABLE</DefineConstants>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/LambdaS3FileZipper/Models/Request.cs
+++ b/LambdaS3FileZipper/Models/Request.cs
@@ -5,7 +5,6 @@ namespace LambdaS3FileZipper.Models
         // Empty constructor required for serialization
         public Request()
         {
-
         }
 
 		public Request(
@@ -13,13 +12,15 @@ namespace LambdaS3FileZipper.Models
 			string originResourceName,
 			string destinationBucketName,
 			string destinationResourceName,
-			bool flatZipFile)
+			bool flatZipFile,
+			string originResourceExpressionPattern = null)
 		{
 			OriginBucketName = originBucketName;
 			OriginResourceName = originResourceName;
 			DestinationBucketName = destinationBucketName;
 			DestinationResourceName = destinationResourceName;
-			FlatZipFile = flatZipFile;
+		    FlatZipFile = flatZipFile;
+		    OriginResourceExpressionPattern = originResourceExpressionPattern;
 		}
 
 		public string OriginBucketName { get; set; }
@@ -27,5 +28,6 @@ namespace LambdaS3FileZipper.Models
 		public string DestinationBucketName { get; set; }
 		public string DestinationResourceName { get; set; }
 		public bool FlatZipFile { get; set; }
+        public string OriginResourceExpressionPattern { get; set; }
 	}
 }

--- a/LambdaS3FileZipper/Service.cs
+++ b/LambdaS3FileZipper/Service.cs
@@ -18,12 +18,13 @@ namespace LambdaS3FileZipper
 		    this.fileRetriever = fileRetriever;
 		    this.fileZipper = fileZipper;
 		    this.fileUploader = fileUploader;
+
 		    this.log = LogProvider.GetCurrentClassLogger();
 	    }
 
-	    public async Task<Response> Process(Request request, CancellationToken cancellationToken = default(CancellationToken))
+	    public async Task<Response> Process(Request request, CancellationToken cancellationToken = default)
 	    {
-		    var directory = await fileRetriever.Retrieve(request.OriginBucketName, request.OriginResourceName, cancellationToken);
+		    var directory = await fileRetriever.Retrieve(request.OriginBucketName, request.OriginResourceName, request.OriginResourceExpressionPattern, cancellationToken);
 		    log.Debug("Retrieved files from {Bucket}:{Resource} into directory {Directory}",
 		        request.OriginBucketName, request.OriginResourceName, directory);
 


### PR DESCRIPTION
Introduces a new param `string OriginResourceExpressionPattern` that's consumed as a RegEx pattern for file filtering post-retrieval. There's no way to currently filter files on `S3` server-side, besides setting the `Prefix` param. This change will list all files and then filter the resulted collection.

By default, the function will use `.*` pattern when none is provided.