### PR TITLE
Implement methods for retrieving files from AWS S3 into memory as FileResponses

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4

--- a/LambdaS3FileZipper.IntegrationTests/Aws/AwsS3ClientFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/AwsS3ClientFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -27,30 +28,29 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 			DeleteLocalTempFile(localPath);
 		}
 
-        [Test]
-        public async Task Download_ToMemory_ShouldRetrieveObject()
-        {
-            Console.WriteLine("Downloading {0}:{1}", TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName);
-            using (var fileResource = await Client.Download(TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName, CancellationToken.None))
-            {
-                var localPath = Path.GetTempFileName();
+		[Test]
+		public async Task Download_ToMemory_ShouldRetrieveObject()
+		{
+			Console.WriteLine("Downloading {0}:{1}", TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName);
+			using var fileResource = await Client.Download(TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName, CancellationToken.None);
 
-                using (var fileStream = File.OpenWrite(localPath))
-                {
-                    await fileResource.ContentStream.CopyToAsync(fileStream);
-                }
+			var localPath = Path.GetTempFileName();
+			using (var fileStream = File.OpenWrite(localPath))
+			{
+				await fileResource.ContentStream.CopyToAsync(fileStream);
+			}
 
-                Console.WriteLine("Downloaded to {0}", localPath);
+			Console.WriteLine("Downloaded to {0}", localPath);
+			Debugger.Break();
 
-                var localFile = new FileInfo(localPath);
-                Assert.That(localFile.Exists, Is.True);
-                Assert.That(localFile.Length, Is.GreaterThan(0));
+			var localFile = new FileInfo(localPath);
+			Assert.That(localFile.Exists, Is.True);
+			Assert.That(localFile.Length, Is.GreaterThan(0));
 
-                DeleteLocalTempFile(localPath);
-            }
-        }
+			DeleteLocalTempFile(localPath);
+		}
 
-        [Test]
+		[Test]
 		public async Task Upload_ShouldSaveFile()
 		{
 			const string testFileName = "uploadTest.txt";

--- a/LambdaS3FileZipper.IntegrationTests/Aws/AwsS3ClientFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/AwsS3ClientFixture.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using LambdaS3FileZipper.IntegrationTests.Extensions;
 using NUnit.Framework;
 
 namespace LambdaS3FileZipper.IntegrationTests.Aws
@@ -32,20 +33,13 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 		public async Task Download_ToMemory_ShouldRetrieveObject()
 		{
 			Console.WriteLine("Downloading {0}:{1}", TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName);
-			using var fileResource = await Client.Download(TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName, CancellationToken.None);
+			using var fileResponse = await Client.Download(TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName, CancellationToken.None);
 
-			var localPath = Path.GetTempFileName();
-			using (var fileStream = File.OpenWrite(localPath))
-			{
-				await fileResource.ContentStream.CopyToAsync(fileStream);
-			}
-
+			var localPath = await fileResponse.WriteToTempFile();
 			Console.WriteLine("Downloaded to {0}", localPath);
 			Debugger.Break();
 
-			var localFile = new FileInfo(localPath);
-			Assert.That(localFile.Exists, Is.True);
-			Assert.That(localFile.Length, Is.GreaterThan(0));
+			AssertFileIsValid(localPath);
 
 			DeleteLocalTempFile(localPath);
 		}

--- a/LambdaS3FileZipper.IntegrationTests/Aws/AwsS3ClientFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/AwsS3ClientFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,7 +27,30 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 			DeleteLocalTempFile(localPath);
 		}
 
-		[Test]
+        [Test]
+        public async Task Download_ToMemory_ShouldRetrieveObject()
+        {
+            Console.WriteLine("Downloading {0}:{1}", TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName);
+            using (var fileResource = await Client.Download(TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName, CancellationToken.None))
+            {
+                var localPath = Path.GetTempFileName();
+
+                using (var fileStream = File.OpenWrite(localPath))
+                {
+                    await fileResource.ContentStream.CopyToAsync(fileStream);
+                }
+
+                Console.WriteLine("Downloaded to {0}", localPath);
+
+                var localFile = new FileInfo(localPath);
+                Assert.That(localFile.Exists, Is.True);
+                Assert.That(localFile.Length, Is.GreaterThan(0));
+
+                DeleteLocalTempFile(localPath);
+            }
+        }
+
+        [Test]
 		public async Task Upload_ShouldSaveFile()
 		{
 			const string testFileName = "uploadTest.txt";

--- a/LambdaS3FileZipper.IntegrationTests/Aws/S3FileRetrieverFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/S3FileRetrieverFixture.cs
@@ -1,7 +1,9 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.Aws;
+using LambdaS3FileZipper.IntegrationTests.Extensions;
 using NUnit.Framework;
 
 namespace LambdaS3FileZipper.IntegrationTests.Aws
@@ -29,5 +31,24 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 
 			DeleteLocalTempDirectory(directoryPath);
 		}
+
+		[Test]
+		public async Task RetrieveToMemory_ShouldDownloadAllFiles()
+		{
+			var resourceExpressionPattern = "^test.*png$";
+			var fileResponses = await fileRetriever.RetrieveToMemory(TestEnvironment.IntegrationTestBucket, fileKey: "test", resourceExpressionPattern);
+
+			foreach (var fileResponse in fileResponses)
+			{
+				var localPath = await fileResponse.WriteToTempFile();
+				Console.WriteLine("Downloaded to {0}", localPath);
+				Debugger.Break();
+
+				AssertFileIsValid(localPath);
+
+				DeleteLocalTempFile(localPath);
+			}
+		}
+
 	}
 }

--- a/LambdaS3FileZipper.IntegrationTests/Aws/S3FileRetrieverFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/S3FileRetrieverFixture.cs
@@ -17,10 +17,10 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 		}
 
 		[Test]
-		public async Task Retrieve_ShouldDownloadAllFiles()
+		public async Task RetrieveToLocalDirectory_ShouldDownloadAllFiles()
 		{
 			var resourceExpressionPattern = ".*png$";
-			var directoryPath = await fileRetriever.Retrieve(TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName, resourceExpressionPattern);
+			var directoryPath = await fileRetriever.RetrieveToLocalDirectory(TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName, resourceExpressionPattern);
 
 			var directory = new DirectoryInfo(directoryPath);
 			Debugger.Break();

--- a/LambdaS3FileZipper.IntegrationTests/Aws/S3FileRetrieverFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/S3FileRetrieverFixture.cs
@@ -1,5 +1,5 @@
-﻿using System.IO;
-using System.Threading;
+﻿using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.Aws;
 using NUnit.Framework;
@@ -19,11 +19,15 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 		[Test]
 		public async Task Retrieve_ShouldDownloadAllFiles()
 		{
-			var directory = await fileRetriever.Retrieve(TestEnvironment.IntegrationTestBucket, "test.png", resourceExpressionPattern: ".*");
+			var resourceExpressionPattern = ".*png$";
+			var directoryPath = await fileRetriever.Retrieve(TestEnvironment.IntegrationTestBucket, TestEnvironment.IntegrationTestResourceName, resourceExpressionPattern);
 
-			Assert.IsTrue(Directory.Exists(directory));
+			var directory = new DirectoryInfo(directoryPath);
+			Debugger.Break();
+			Assert.That(directory.Exists);
+			Assert.That(directory.GetFiles(), Is.Not.Empty);
 
-			DeleteLocalTempDirectory(directory);
+			DeleteLocalTempDirectory(directoryPath);
 		}
 	}
 }

--- a/LambdaS3FileZipper.IntegrationTests/Aws/S3Fixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/S3Fixture.cs
@@ -1,7 +1,9 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon;
+using Amazon.Runtime;
 using Amazon.S3;
 using LambdaS3FileZipper.Aws;
 using LambdaS3FileZipper.IntegrationTests.Aws.Interfaces;
@@ -64,6 +66,13 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 			{
 				Log.Warn("Could not delete S3 object {ResourceName}", resourceName);
 			}
+		}
+
+		protected void AssertFileIsValid(string filePath)
+		{
+			var file = new FileInfo(filePath);
+			Assert.That(file.Exists, Is.True);
+			Assert.That(file.Length, Is.GreaterThan(0));
 		}
 	}
 }

--- a/LambdaS3FileZipper.IntegrationTests/Extensions/FileResponseTestingExtensions.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Extensions/FileResponseTestingExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using LambdaS3FileZipper.Models;
+
+namespace LambdaS3FileZipper.IntegrationTests.Extensions
+{
+	public static class FileResponseTestingExtensions
+	{
+		public static async Task<string> WriteToTempFile(this FileResponse fileResponse)
+		{
+			var tempFile = Path.GetTempFileName();
+			await fileResponse.WriteTo(tempFile);
+
+			return tempFile;
+		}
+
+		public static async Task WriteTo(this FileResponse fileResponse, string filePath)
+		{
+			using var fileStream = File.OpenWrite(filePath);
+			await fileResponse.ContentStream.CopyToAsync(fileStream);
+		}
+	}
+}

--- a/LambdaS3FileZipper.IntegrationTests/LambdaS3FileZipper.IntegrationTests.csproj
+++ b/LambdaS3FileZipper.IntegrationTests/LambdaS3FileZipper.IntegrationTests.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
 	<PropertyGroup>
 		<TargetFramework>netcoreapp2.0</TargetFramework>
-
 		<IsPackable>false</IsPackable>
-
-		<LangVersion>7.1</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="LibLog" Version="5.0.0" />
 		<PackageReference Include="NSubstitute" Version="3.1.0" />
@@ -15,9 +11,7 @@
 		<PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
 	</ItemGroup>
-
 	<ItemGroup>
 	  <ProjectReference Include="..\..\aws-lambda-s3-zipper-dotnet\LambdaS3FileZipper\LambdaS3FileZipper.csproj" />
 	</ItemGroup>
-
 </Project>

--- a/LambdaS3FileZipper.Test/Aws/S3FileRetrieverFixture.cs
+++ b/LambdaS3FileZipper.Test/Aws/S3FileRetrieverFixture.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using System.Linq;
 using LambdaS3FileZipper.Aws;
 using LambdaS3FileZipper.Exceptions;
+using LambdaS3FileZipper.Models;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -14,19 +16,26 @@ namespace LambdaS3FileZipper.Test.Aws
 
 		private IAwsS3Client s3Client;
 
-		private string testBucket = "test-bucket";
-		private string testResource = "test-resource";
-		private string[] testFiles = { "file1", "file2" };
+		private string bucket;
+		private string existingResource;
+		private string notFoundResource;
+		private string[] files;
 		private CancellationToken cancellationToken;
 
 		[SetUp]
 		public void SetUp()
 		{
+			bucket = "test-bucket";
+			existingResource = "test-resource";
+			notFoundResource = "not-found";
+			files = new[] {"file1", "file2"};
 			cancellationToken = CancellationToken.None;
 
 			s3Client = Substitute.For<IAwsS3Client>();
-			s3Client.List(testBucket, testResource, Arg.Any<CancellationToken>()).Returns(testFiles);
-			s3Client.Download(testBucket, Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
+			s3Client.List(bucket, existingResource, cancellationToken).Returns(files);
+			s3Client.List(bucket, notFoundResource, cancellationToken).Returns(new string[] { });
+			s3Client.Download(bucket, resource: Arg.Any<string>(), destinationPath: Arg.Any<string>(), cancellationToken);
+			s3Client.Download(bucket, resourceKey: Arg.Any<string>(), cancellationToken).Returns(new FileResponse("key", default));
 
 			fileRetriever = new S3FileRetriever(s3Client);
 		}
@@ -34,25 +43,23 @@ namespace LambdaS3FileZipper.Test.Aws
 		[Test]
 		public async Task RetrieveToLocalDirectory_ShouldReturnObjectPaths()
 		{
-			var directory = await fileRetriever.RetrieveToLocalDirectory(testBucket, testResource, cancellationToken: cancellationToken);
+			var directory = await fileRetriever.RetrieveToLocalDirectory(bucket, existingResource, cancellationToken: cancellationToken);
 
 			Assert.IsNotNull(directory);
-			await s3Client.Received(1).List(testBucket, testResource, cancellationToken);
-			foreach (var file in testFiles)
+			await s3Client.Received(1).List(bucket, existingResource, cancellationToken);
+			foreach (var file in files)
 			{
-				await s3Client.Received(1).Download(testBucket, file, directory, cancellationToken);
+				await s3Client.Received(1).Download(bucket, file, directory, cancellationToken);
 			}
 		}
 
 	    [Test]
 	    public async Task RetrieveToLocalDirectory_ShouldReturnEmptyCollectionWhenNoFilesAreFound()
 	    {
-	        testResource = "not-found";
+            Assert.ThrowsAsync<ResourceNotFoundException>(() => fileRetriever.RetrieveToLocalDirectory(bucket, notFoundResource, cancellationToken: cancellationToken));
 
-            Assert.ThrowsAsync<ResourceNotFoundException>(() => fileRetriever.RetrieveToLocalDirectory(testBucket, testResource, cancellationToken: cancellationToken));
-
-	        await s3Client.Received(1).List(testBucket, testResource, cancellationToken);
-	        await s3Client.DidNotReceive().Download(testBucket, Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
+	        await s3Client.Received(1).List(bucket, notFoundResource, cancellationToken);
+	        await s3Client.DidNotReceive().Download(bucket, Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
 	    }
 
         [Test]
@@ -60,11 +67,48 @@ namespace LambdaS3FileZipper.Test.Aws
 	    {
 	        var resourceMatchExpression = @".*2";
 
-	        await fileRetriever.RetrieveToLocalDirectory(testBucket, testResource, resourceMatchExpression, cancellationToken);
+	        await fileRetriever.RetrieveToLocalDirectory(bucket, existingResource, resourceMatchExpression, cancellationToken);
 
-	        await s3Client.Received(1).List(testBucket, testResource, cancellationToken);
-	        await s3Client.DidNotReceive().Download(testBucket, "file1", Arg.Any<string>(), cancellationToken);
-	        await s3Client.Received(1).Download(testBucket, "file2", Arg.Any<string>(), cancellationToken);
+	        await s3Client.Received(1).List(bucket, existingResource, cancellationToken);
+	        await s3Client.DidNotReceive().Download(bucket, "file1", Arg.Any<string>(), cancellationToken);
+	        await s3Client.Received(1).Download(bucket, "file2", Arg.Any<string>(), cancellationToken);
         }
+
+	    [Test]
+	    public async Task RetrieveToMemory_ShouldReturnObjectPaths()
+	    {
+		    var fileResponses = await fileRetriever.RetrieveToMemory(bucket, existingResource, cancellationToken: cancellationToken);
+
+		    Assert.That(fileResponses, Is.Not.Empty);
+		    Assert.That(fileResponses.Count(), Is.EqualTo(2));
+		    await s3Client.Received(1).List(bucket, existingResource, cancellationToken);
+		    foreach (var file in files)
+		    {
+			    await s3Client.Received(1).Download(bucket, file, cancellationToken);
+		    }
+	    }
+
+	    [Test]
+	    public async Task RetrieveToMemory_ShouldReturnEmptyCollectionWhenNoFilesAreFound()
+	    {
+		    Assert.ThrowsAsync<ResourceNotFoundException>(() => fileRetriever.RetrieveToMemory(bucket, notFoundResource, cancellationToken: cancellationToken));
+
+		    await s3Client.Received(1).List(bucket, notFoundResource, cancellationToken);
+		    await s3Client.DidNotReceive().Download(bucket, Arg.Any<string>(), cancellationToken);
+	    }
+
+	    [Test]
+	    public async Task RetrieveToMemory_ShouldReturnOnlyFilesMatchingExpression()
+	    {
+		    var resourceMatchExpression = @".*2";
+
+		    var fileResponses = await fileRetriever.RetrieveToMemory(bucket, existingResource, resourceMatchExpression, cancellationToken);
+
+		    Assert.That(fileResponses, Is.Not.Empty);
+		    Assert.That(fileResponses.Count(), Is.EqualTo(1));
+			await s3Client.Received(1).List(bucket, existingResource, cancellationToken);
+		    await s3Client.DidNotReceive().Download(bucket, "file1", cancellationToken);
+		    await s3Client.Received(1).Download(bucket, "file2", cancellationToken);
+	    }
 	}
 }

--- a/LambdaS3FileZipper.Test/Aws/S3FileRetrieverFixture.cs
+++ b/LambdaS3FileZipper.Test/Aws/S3FileRetrieverFixture.cs
@@ -32,9 +32,9 @@ namespace LambdaS3FileZipper.Test.Aws
 		}
 
 		[Test]
-		public async Task Retrieve_ShouldReturnObjectPaths()
+		public async Task RetrieveToLocalDirectory_ShouldReturnObjectPaths()
 		{
-			var directory = await fileRetriever.Retrieve(testBucket, testResource, cancellationToken: cancellationToken);
+			var directory = await fileRetriever.RetrieveToLocalDirectory(testBucket, testResource, cancellationToken: cancellationToken);
 
 			Assert.IsNotNull(directory);
 			await s3Client.Received(1).List(testBucket, testResource, cancellationToken);
@@ -45,22 +45,22 @@ namespace LambdaS3FileZipper.Test.Aws
 		}
 
 	    [Test]
-	    public async Task Retrieve_ShouldReturnEmptyCollectionWhenNoFilesAreFound()
+	    public async Task RetrieveToLocalDirectory_ShouldReturnEmptyCollectionWhenNoFilesAreFound()
 	    {
 	        testResource = "not-found";
 
-            Assert.ThrowsAsync<ResourceNotFoundException>(() => fileRetriever.Retrieve(testBucket, testResource, cancellationToken: cancellationToken));
+            Assert.ThrowsAsync<ResourceNotFoundException>(() => fileRetriever.RetrieveToLocalDirectory(testBucket, testResource, cancellationToken: cancellationToken));
 
 	        await s3Client.Received(1).List(testBucket, testResource, cancellationToken);
 	        await s3Client.DidNotReceive().Download(testBucket, Arg.Any<string>(), Arg.Any<string>(), cancellationToken);
 	    }
 
         [Test]
-	    public async Task Retrieve_ShouldReturnOnlyFilesMatchingExpression()
+	    public async Task RetrieveToLocalDirectory_ShouldReturnOnlyFilesMatchingExpression()
 	    {
 	        var resourceMatchExpression = @".*2";
 
-	        await fileRetriever.Retrieve(testBucket, testResource, resourceMatchExpression, cancellationToken);
+	        await fileRetriever.RetrieveToLocalDirectory(testBucket, testResource, resourceMatchExpression, cancellationToken);
 
 	        await s3Client.Received(1).List(testBucket, testResource, cancellationToken);
 	        await s3Client.DidNotReceive().Download(testBucket, "file1", Arg.Any<string>(), cancellationToken);

--- a/LambdaS3FileZipper.Test/LambdaS3FileZipper.Test.csproj
+++ b/LambdaS3FileZipper.Test/LambdaS3FileZipper.Test.csproj
@@ -1,22 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\LambdaS3FileZipper\LambdaS3FileZipper.csproj" />
   </ItemGroup>
-
 </Project>

--- a/LambdaS3FileZipper.Test/ServiceFixture.cs
+++ b/LambdaS3FileZipper.Test/ServiceFixture.cs
@@ -31,7 +31,7 @@ namespace LambdaS3FileZipper.Test
 			url = "s3.com/compressed-file";
 
 			fileRetriever = Substitute.For<IFileRetriever>();
-			fileRetriever.Retrieve(request.OriginBucketName, request.OriginResourceName, Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(directory);
+			fileRetriever.RetrieveToLocalDirectory(request.OriginBucketName, request.OriginResourceName, Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(directory);
 
 			fileZipper = Substitute.For<IFileZipper>();
 			fileZipper.Compress(directory, Arg.Any<bool>()).Returns(compressedFile);
@@ -55,7 +55,7 @@ namespace LambdaS3FileZipper.Test
 		{
 			await service.Process(request);
 
-			await fileRetriever.Received().Retrieve(request.OriginBucketName, request.OriginResourceName);
+			await fileRetriever.Received().RetrieveToLocalDirectory(request.OriginBucketName, request.OriginResourceName);
 		}
 
 		[Test]

--- a/LambdaS3FileZipper.sln
+++ b/LambdaS3FileZipper.sln
@@ -1,13 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LambdaS3FileZipper", "LambdaS3FileZipper\LambdaS3FileZipper.csproj", "{A87930C6-8082-4760-83BE-272FD39E036D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LambdaS3FileZipper.Test", "LambdaS3FileZipper.Test\LambdaS3FileZipper.Test.csproj", "{21982D49-2F6C-4A11-868D-6B04880C38F2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LambdaS3FileZipper.IntegrationTests", "LambdaS3FileZipper.IntegrationTests\LambdaS3FileZipper.IntegrationTests.csproj", "{26165F86-E52F-41BB-97B0-1B24979CB826}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{33D5B0B1-183E-4E17-ABFC-ACA6291061C1}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/LambdaS3FileZipper/Aws/AwsS3Client.cs
+++ b/LambdaS3FileZipper/Aws/AwsS3Client.cs
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
+using LambdaS3FileZipper.Extensions;
+using LambdaS3FileZipper.Models;
 
 namespace LambdaS3FileZipper.Aws
 {
@@ -72,7 +74,16 @@ namespace LambdaS3FileZipper.Aws
 			return localPath;
 		}
 
-		public async Task Upload(string bucketName, string resourceName, string filePath, CancellationToken cancellationToken)
+        public async Task<FileResponse> Download(string bucketName, string resourceKey, CancellationToken cancellationToken)
+        {
+            var request = new GetObjectRequest {BucketName = bucketName, Key = resourceKey};
+            using (var response = await client.GetObjectAsync(request, cancellationToken))
+            {
+                return new FileResponse(resourceKey, await response.ResponseStream.CopyStreamOntoMemory(cancellationToken));
+            }
+        }
+
+        public async Task Upload(string bucketName, string resourceName, string filePath, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 

--- a/LambdaS3FileZipper/Aws/Interfaces/IAwsS3Client.cs
+++ b/LambdaS3FileZipper/Aws/Interfaces/IAwsS3Client.cs
@@ -1,6 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using LambdaS3FileZipper.Models;
 
 namespace LambdaS3FileZipper
 {
@@ -8,6 +11,7 @@ namespace LambdaS3FileZipper
     {
 	    Task<IEnumerable<string>> List(string bucketName, string resource, CancellationToken cancellationToken);
 	    Task<string> Download(string bucketName, string resource, string destinationPath, CancellationToken cancellationToken);
+        Task<FileResponse> Download(string bucketName, string resourceKey, CancellationToken cancellationToken);
 	    Task Upload(string bucketName, string resourceName, string filePath, CancellationToken cancellationToken);
 	    Task Delete(string bucketName, string resourceName, CancellationToken cancellationToken);
 	    string GenerateUrl(string bucketName, string resourceName);

--- a/LambdaS3FileZipper/Aws/S3FileRetriever.cs
+++ b/LambdaS3FileZipper/Aws/S3FileRetriever.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -25,26 +26,13 @@ namespace LambdaS3FileZipper.Aws
 			this.log = LogProvider.GetCurrentClassLogger();
 		}
 
-		public async Task<string> Retrieve(
+		public async Task<string> RetrieveToLocalDirectory(
 		    string bucket,
 		    string resource,
             string resourceExpressionPattern = default,
 		    CancellationToken cancellationToken = default)
 		{
-		    if (string.IsNullOrWhiteSpace(resourceExpressionPattern))
-		    {
-		        resourceExpressionPattern = DefaultResourceExpressionPattern;
-            }
-
-            log.Debug("Using resource name expression pattern {resourceExpressionPattern}", resourceExpressionPattern);
-		    var regex = new Regex(resourceExpressionPattern, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Singleline);
-            var files = (await s3Client.List(bucket, resource, cancellationToken)).Where(file => regex.IsMatch(file)).ToArray();
-		    if (files.Any() == false)
-			{
-				log.Warn("There are no files listed under {bucket}/{resource} that match expression {resourceExpressionPattern}; nothing to ZIP",
-				    bucket, resource, resourceExpressionPattern);
-				throw new ResourceNotFoundException(bucket, resource, resourceExpressionPattern);
-			}
+		    var files = await FindFilesMatchingExpression(bucket, resource, resourceExpressionPattern, cancellationToken);
 
 			var downloadPath = Path.Combine(Path.GetTempPath(), bucket);
 			if (Directory.Exists(downloadPath))
@@ -52,31 +40,53 @@ namespace LambdaS3FileZipper.Aws
 				Directory.Delete(downloadPath, recursive: true);
 			}
 
-			using (var throttler = new SemaphoreSlim(MaxConcurrentDownloads))
-			{
-				var tasks = new List<Task>();
-
-				foreach (var file in files)
-				{
-					await throttler.WaitAsync(cancellationToken);
-
-					tasks.Add(Task.Run(async () =>
-					{
-						try
-						{
-							await s3Client.Download(bucket, file, downloadPath, cancellationToken);
-						}
-						finally
-						{
-							throttler.Release();
-						}
-					}, cancellationToken));
-				}
-
-				await Task.WhenAll(tasks.ToArray());
-			}
-			
+			await RetrieveConcurrently(files, retrieveEachFile: file => s3Client.Download(bucket, file, downloadPath, cancellationToken), cancellationToken);
 			return downloadPath;
+		}
+
+		private async Task<string[]> FindFilesMatchingExpression(
+			string bucket,
+			string resource,
+			string resourceExpressionPattern = default,
+			CancellationToken cancellationToken = default)
+		{
+			resourceExpressionPattern ??= DefaultResourceExpressionPattern;
+			log.Debug("Using resource name expression pattern {resourceExpressionPattern}", resourceExpressionPattern);
+
+			var regex = new Regex(resourceExpressionPattern, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+			var files = (await s3Client.List(bucket, resource, cancellationToken)).Where(file => regex.IsMatch(file)).ToArray();
+			if (files.Any() == false)
+			{
+				log.Warn("No files under {bucket}/{resource} matching {resourceExpressionPattern}", bucket, resource, resourceExpressionPattern);
+				throw new ResourceNotFoundException(bucket, resource, resourceExpressionPattern);
+			}
+
+			return files;
+		}
+
+		private static async Task RetrieveConcurrently(string[] files, Func<string, Task> retrieveEachFile, CancellationToken cancellationToken)
+		{
+			using var throttler = new SemaphoreSlim(MaxConcurrentDownloads);
+
+			var tasks = new List<Task>();
+			foreach (var file in files)
+			{
+				await throttler.WaitAsync(cancellationToken);
+
+				tasks.Add(Task.Run(async () =>
+				{
+					try
+					{
+						await retrieveEachFile(file);
+					}
+					finally
+					{
+						throttler.Release();
+					}
+				}, cancellationToken));
+			}
+
+			await Task.WhenAll(tasks.ToArray());
 		}
 	}
 }

--- a/LambdaS3FileZipper/Extensions/StreamExtensions.cs
+++ b/LambdaS3FileZipper/Extensions/StreamExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LambdaS3FileZipper.Extensions
+{
+    public static class StreamExtensions
+    {
+        public static async Task<Stream> CopyStreamOntoMemory(this Stream stream, CancellationToken cancellationToken = default)
+        {
+            var memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream, 4096, cancellationToken).ConfigureAwait(false);
+            return memoryStream.Reset();
+        }
+
+        public static Stream Reset(this Stream stream)
+        {
+            if (stream.CanSeek)
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+            }
+
+            return stream;
+        }
+    }
+}

--- a/LambdaS3FileZipper/Interfaces/IFileRetriever.cs
+++ b/LambdaS3FileZipper/Interfaces/IFileRetriever.cs
@@ -1,10 +1,12 @@
 using System.Threading;
 using System.Threading.Tasks;
+using LambdaS3FileZipper.Models;
 
 namespace LambdaS3FileZipper.Interfaces
 {
 	public interface IFileRetriever
 	{
 		Task<string> RetrieveToLocalDirectory(string bucket, string resource, string resourceExpressionPattern = default, CancellationToken cancellationToken = default);
+		Task<FileResponse[]> RetrieveToMemory(string bucket, string fileKey, string resourceExpressionPattern = default, CancellationToken cancellationToken = default);
 	}
 }

--- a/LambdaS3FileZipper/Interfaces/IFileRetriever.cs
+++ b/LambdaS3FileZipper/Interfaces/IFileRetriever.cs
@@ -5,6 +5,6 @@ namespace LambdaS3FileZipper.Interfaces
 {
 	public interface IFileRetriever
 	{
-		Task<string> Retrieve(string bucket, string resource, string resourceExpressionPattern = null, CancellationToken cancellationToken = default);
+		Task<string> RetrieveToLocalDirectory(string bucket, string resource, string resourceExpressionPattern = default, CancellationToken cancellationToken = default);
 	}
 }

--- a/LambdaS3FileZipper/LambdaS3FileZipper.csproj
+++ b/LambdaS3FileZipper/LambdaS3FileZipper.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -12,9 +11,8 @@
     <FileVersion>1.0.1.0</FileVersion>
     <Version Condition="'$(VersionSuffix)' != ''">1.0.1.$(VersionSuffix)</Version>
     <DefineConstants>LIBLOG_PORTABLE</DefineConstants>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>

--- a/LambdaS3FileZipper/Models/FileResponse.cs
+++ b/LambdaS3FileZipper/Models/FileResponse.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.IO;
+
+namespace LambdaS3FileZipper.Models
+{
+    public class FileResponse : IDisposable
+    {
+        public FileResponse(string resourceKey, Stream contentStream)
+        {
+            ResourceKey = resourceKey;
+            ContentStream = contentStream;
+        }
+
+        public string ResourceKey { get; set; }
+        public Stream ContentStream { get; set; }
+
+        public void Dispose()
+        {
+            ContentStream?.Dispose();
+        }
+    }
+}

--- a/LambdaS3FileZipper/Service.cs
+++ b/LambdaS3FileZipper/Service.cs
@@ -24,7 +24,7 @@ namespace LambdaS3FileZipper
 
 	    public async Task<Response> Process(Request request, CancellationToken cancellationToken = default)
 	    {
-		    var directory = await fileRetriever.Retrieve(request.OriginBucketName, request.OriginResourceName, request.OriginResourceExpressionPattern, cancellationToken);
+		    var directory = await fileRetriever.RetrieveToLocalDirectory(request.OriginBucketName, request.OriginResourceName, request.OriginResourceExpressionPattern, cancellationToken);
 		    log.Debug("Retrieved files from {Bucket}:{Resource} into directory {Directory}",
 		        request.OriginBucketName, request.OriginResourceName, directory);
 


### PR DESCRIPTION
#### Background

Due to reports that ZIP requests are running out of space, and the fixed value of AWS Lambda function storage of `512 MB`, we are re-implementing the `aws-lambda-s3-zipper` to store content in memory, which can be scaled up in AWS Lambda up to `5120 MB`.

#### Solution

The current changes implement a way for retrieving files into memory, on:

- Updates `AwsS3Client` to return `FileResponse` file reference (https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/31/commits/2af893aa0dac0246044251219f0dd94ac06331be)
- Updates `S3FileRetriever` to return a collection of `FileResponses`, each containing a file content stream (https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/31/commits/23cf0a469fcb7f927bdcaccdc4cd5e04e6e3f75b)