### PR TITLE
Implement way to compress in-memory FileResponse streams

### DIFF
--- a/LambdaS3FileZipper.IntegrationTests/Aws/AwsS3ClientFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/AwsS3ClientFixture.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.IntegrationTests.Extensions;
 using NUnit.Framework;
+using FileAssert = LambdaS3FileZipper.IntegrationTests.Testing.FileAssert;
 
 namespace LambdaS3FileZipper.IntegrationTests.Aws
 {
@@ -39,7 +40,7 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 			Console.WriteLine("Downloaded to {0}", localPath);
 			Debugger.Break();
 
-			AssertFileIsValid(localPath);
+			FileAssert.HasContent(localPath);
 
 			DeleteLocalTempFile(localPath);
 		}

--- a/LambdaS3FileZipper.IntegrationTests/Aws/S3FileRetrieverFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/S3FileRetrieverFixture.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using LambdaS3FileZipper.Aws;
 using LambdaS3FileZipper.IntegrationTests.Extensions;
 using NUnit.Framework;
+using FileAssert = LambdaS3FileZipper.IntegrationTests.Testing.FileAssert;
 
 namespace LambdaS3FileZipper.IntegrationTests.Aws
 {
@@ -44,7 +45,7 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 				Console.WriteLine("Downloaded to {0}", localPath);
 				Debugger.Break();
 
-				AssertFileIsValid(localPath);
+				FileAssert.HasContent(localPath);
 
 				DeleteLocalTempFile(localPath);
 			}

--- a/LambdaS3FileZipper.IntegrationTests/Aws/S3Fixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/S3Fixture.cs
@@ -68,12 +68,5 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 				Log.Warn("Could not delete S3 object {ResourceName}", resourceName);
 			}
 		}
-
-		protected void AssertFileIsValid(string filePath)
-		{
-			var file = new FileInfo(filePath);
-			Assert.That(file.Exists, Is.True);
-			Assert.That(file.Length, Is.GreaterThan(0));
-		}
 	}
 }

--- a/LambdaS3FileZipper.IntegrationTests/Aws/S3Fixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/S3Fixture.cs
@@ -8,6 +8,7 @@ using Amazon.S3;
 using LambdaS3FileZipper.Aws;
 using LambdaS3FileZipper.IntegrationTests.Aws.Interfaces;
 using LambdaS3FileZipper.IntegrationTests.Logging;
+using LambdaS3FileZipper.Interfaces;
 using NUnit.Framework;
 
 namespace LambdaS3FileZipper.IntegrationTests.Aws

--- a/LambdaS3FileZipper.IntegrationTests/Extensions/FileResponseTestingExtensions.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Extensions/FileResponseTestingExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
+using LambdaS3FileZipper.Extensions;
 using LambdaS3FileZipper.Models;
 
 namespace LambdaS3FileZipper.IntegrationTests.Extensions
@@ -18,6 +19,7 @@ namespace LambdaS3FileZipper.IntegrationTests.Extensions
 		{
 			using var fileStream = File.OpenWrite(filePath);
 			await fileResponse.ContentStream.CopyToAsync(fileStream);
+			fileResponse.ContentStream.Reset();
 		}
 	}
 }

--- a/LambdaS3FileZipper.IntegrationTests/FileZipperFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/FileZipperFixture.cs
@@ -6,9 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.Extensions;
 using LambdaS3FileZipper.IntegrationTests.Extensions;
-using LambdaS3FileZipper.IntegrationTests.Logging;
 using LambdaS3FileZipper.Models;
 using NUnit.Framework;
+using FileAssert = LambdaS3FileZipper.IntegrationTests.Testing.FileAssert;
 
 namespace LambdaS3FileZipper.IntegrationTests
 {
@@ -55,7 +55,6 @@ namespace LambdaS3FileZipper.IntegrationTests
 			}
 		}
 
-
 		[Test]
 		public async Task Compress_ShouldZipFilesInMemory()
 		{
@@ -78,6 +77,8 @@ namespace LambdaS3FileZipper.IntegrationTests
 				await zipFileResponse.WriteTo(zipFilePath);
 				Console.WriteLine("Created zipFilePath at {0}", zipFilePath);
 				Debugger.Break();
+
+				FileAssert.HasContent(zipFilePath);
 			}
 			finally
 			{

--- a/LambdaS3FileZipper.IntegrationTests/Testing/FileAssert.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Testing/FileAssert.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+using NUnit.Framework;
+
+namespace LambdaS3FileZipper.IntegrationTests.Testing
+{
+	public static class FileAssert
+	{
+		/// <summary>
+		/// Asserts that file at <see cref="filePath"/> exists and is non-empty
+		/// </summary>
+		/// <param name="filePath"></param>
+		public static void HasContent(string filePath)
+		{
+			var file = new FileInfo(filePath);
+			Assert.That(file.Exists, Is.True);
+			Assert.That(file.Length, Is.GreaterThan(0));
+		}
+	}
+}

--- a/LambdaS3FileZipper.Test/Aws/S3FileRetrieverFixture.cs
+++ b/LambdaS3FileZipper.Test/Aws/S3FileRetrieverFixture.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using System.Linq;
 using LambdaS3FileZipper.Aws;
 using LambdaS3FileZipper.Exceptions;
+using LambdaS3FileZipper.Interfaces;
 using LambdaS3FileZipper.Models;
 using NSubstitute;
 using NUnit.Framework;

--- a/LambdaS3FileZipper.Test/Aws/S3FileUploaderFixture.cs
+++ b/LambdaS3FileZipper.Test/Aws/S3FileUploaderFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.Aws;
+using LambdaS3FileZipper.Interfaces;
 using NSubstitute;
 using NUnit.Framework;
 

--- a/LambdaS3FileZipper/Aws/AwsS3Client.cs
+++ b/LambdaS3FileZipper/Aws/AwsS3Client.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
 using LambdaS3FileZipper.Extensions;
+using LambdaS3FileZipper.Interfaces;
 using LambdaS3FileZipper.Models;
 
 namespace LambdaS3FileZipper.Aws

--- a/LambdaS3FileZipper/FileZipper.cs
+++ b/LambdaS3FileZipper/FileZipper.cs
@@ -40,18 +40,26 @@ namespace LambdaS3FileZipper
 
 		public async Task<FileResponse> Compress(string zipFileKey, IEnumerable<FileResponse> filesResponses, CancellationToken cancellationToken)
 		{
-			var zipStream = new MemoryStream();
-			var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Create);
-			foreach (var fileResponse in filesResponses)
-			{
-				var zipEntry = zipArchive.CreateEntry(fileResponse.ResourceKey);
+			var zipMemoryStream = new MemoryStream();
 
-				using var zipEntryStream = zipEntry.Open();
-				using var fileContentStream = fileResponse.ContentStream;
-				await fileContentStream.CopyToAsync(zipEntryStream, 4096, cancellationToken);
+			// In order to allow consumption of the compressed stream:
+			// (1) leaveOpen => true
+			// (2) ZipArchive object needs to be disposed to prevent compressed stream/ZIP file corruption
+			// (disposing runs a number of required finalizers, while keeping stream open :shrug:)
+			// For more info, visit: https://stackoverflow.com/a/17939367/1250033
+			using (var zipArchive = new ZipArchive(zipMemoryStream, ZipArchiveMode.Create, leaveOpen: true))
+			{
+				foreach (var fileResponse in filesResponses)
+				{
+					var zipEntry = zipArchive.CreateEntry(fileResponse.ResourceKey);
+
+					using var zipEntryStream = zipEntry.Open();
+					using var fileContentStream = fileResponse.ContentStream;
+					await fileContentStream.CopyToAsync(zipEntryStream, 4096, cancellationToken);
+				}
 			}
 
-			return new FileResponse(resourceKey: zipFileKey, contentStream: zipStream.Reset());
+			return new FileResponse(resourceKey: zipFileKey, contentStream: zipMemoryStream.Reset());
 		}
 
 		private async Task CreateFlatZip(string localDirectory, string zipPath)

--- a/LambdaS3FileZipper/FileZipper.cs
+++ b/LambdaS3FileZipper/FileZipper.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
+using LambdaS3FileZipper.Extensions;
 using LambdaS3FileZipper.Interfaces;
 using LambdaS3FileZipper.Models;
 
@@ -50,7 +51,7 @@ namespace LambdaS3FileZipper
 				await fileContentStream.CopyToAsync(zipEntryStream, 4096, cancellationToken);
 			}
 
-			return new FileResponse(resourceKey: zipFileKey, contentStream: zipStream);
+			return new FileResponse(resourceKey: zipFileKey, contentStream: zipStream.Reset());
 		}
 
 		private async Task CreateFlatZip(string localDirectory, string zipPath)

--- a/LambdaS3FileZipper/Interfaces/IAwsS3Client.cs
+++ b/LambdaS3FileZipper/Interfaces/IAwsS3Client.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.Models;
 
-namespace LambdaS3FileZipper
+namespace LambdaS3FileZipper.Interfaces
 {
     public interface IAwsS3Client
     {

--- a/LambdaS3FileZipper/Interfaces/IFileZipper.cs
+++ b/LambdaS3FileZipper/Interfaces/IFileZipper.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using LambdaS3FileZipper.Models;
 
 namespace LambdaS3FileZipper.Interfaces
 {
 	public interface IFileZipper
 	{
 		Task<string> Compress(string localDirectory, bool flat);
+		Task<FileResponse> Compress(string zipFileKey, IEnumerable<FileResponse> filesResponses, CancellationToken cancellationToken);
 	}
 }


### PR DESCRIPTION
#### Background

Due to reports that ZIP requests are running out of space, and the fixed value of AWS Lambda function storage of `512 MB`, we are re-implementing the `aws-lambda-s3-zipper` to store content in memory, which can be scaled up in AWS Lambda up to `5120 MB`.

##### Related Changes
- https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/31 Implement methods for retrieving files from **AWS S3** into memory as `FileResponses` 

#### Solution

The current changes implement a way for compressing in-memory files streams to memory:

- Updates `FileZipper` with new `Compress` method that accepts a collection of `FileResponses` and returns a compressed stream (https://github.com/litmus/aws-lambda-s3-zipper-dotnet/commit/61747a2292c9bbedaad9d48c273266b8b85d5054)
- Includes fix for how `ZipArchive` creates compressed files (https://github.com/litmus/aws-lambda-s3-zipper-dotnet/commit/61d0c541e632cb10529ff2a60ef94d80c122c1cb)


