### PR TITLE
Implement methods to upload files to AWS S3 using FileResponse

### DIFF
--- a/LambdaS3FileZipper.IntegrationTests/Aws/AwsS3ClientFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Aws/AwsS3ClientFixture.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.IntegrationTests.Extensions;
+using LambdaS3FileZipper.IntegrationTests.Testing;
 using NUnit.Framework;
 using FileAssert = LambdaS3FileZipper.IntegrationTests.Testing.FileAssert;
 
@@ -61,6 +62,28 @@ namespace LambdaS3FileZipper.IntegrationTests.Aws
 			{
 				DeleteLocalTempFile(localTestFile);
 				await DeleteTempS3Object(TestEnvironment.IntegrationTestBucket, testFileName);
+			}
+		}
+
+		[Test]
+		public async Task Upload_FromMemory_ShouldUploadFileToS3()
+		{
+			var tempDirectory = Path.GetTempPath();
+			var fileKey = Guid.NewGuid().ToString();
+			var fileContent = $"{fileKey}: file was uploaded at {DateTime.UtcNow}";
+			var file = await FileTool.CreateTempTextFile(tempDirectory, fileKey, fileContent);
+			var cancellationToken = CancellationToken.None;
+
+			try
+			{
+				await Client.Upload(TestEnvironment.IntegrationTestBucket, fileKey, file, cancellationToken);
+
+				Debugger.Break();
+			}
+			finally
+			{
+				FileTool.TryDeleteFile(filePath: Path.Combine(tempDirectory, fileKey));
+				await DeleteTempS3Object(TestEnvironment.IntegrationTestBucket, fileKey);
 			}
 		}
 

--- a/LambdaS3FileZipper.IntegrationTests/Testing/FileAssert.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Testing/FileAssert.cs
@@ -6,6 +6,16 @@ namespace LambdaS3FileZipper.IntegrationTests.Testing
 	public static class FileAssert
 	{
 		/// <summary>
+		/// Asserts that file at <see cref="filePath"/> exists
+		/// </summary>
+		/// <param name="filePath"></param>
+		public static void Exists(string filePath)
+		{
+			var file = new FileInfo(filePath);
+			Assert.That(file.Exists, Is.True);
+		}
+
+		/// <summary>
 		/// Asserts that file at <see cref="filePath"/> exists and is non-empty
 		/// </summary>
 		/// <param name="filePath"></param>

--- a/LambdaS3FileZipper.IntegrationTests/Testing/FileTool.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Testing/FileTool.cs
@@ -1,0 +1,38 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using LambdaS3FileZipper.Extensions;
+using LambdaS3FileZipper.Models;
+
+namespace LambdaS3FileZipper.IntegrationTests.Testing
+{
+	public static class FileTool
+	{
+		private static readonly CancellationToken cancellationToken = CancellationToken.None;
+
+		public static void TryDeleteFile(string filePath)
+		{
+			if (File.Exists(filePath))
+			{
+				File.Delete(filePath);
+			}
+		}
+
+		public static void TryDeleteDirectory(string directoryPath, bool recursive = true)
+		{
+			if (Directory.Exists(directoryPath))
+			{
+				Directory.Delete(directoryPath, recursive);
+			}
+		}
+
+		public static async Task<FileResponse> CreateTempTextFile(string directory, string fileKey, string fileContent)
+		{
+			var filePath = Path.Combine(directory, fileKey);
+			await File.WriteAllTextAsync(filePath, fileContent, cancellationToken);
+
+			using var fileStream = File.OpenRead(filePath);
+			return new FileResponse(resourceKey: fileKey, contentStream: await fileStream.CopyStreamOntoMemory(cancellationToken));
+		}
+	}
+}

--- a/LambdaS3FileZipper.Test/Aws/AwsS3ClientFixture.cs
+++ b/LambdaS3FileZipper.Test/Aws/AwsS3ClientFixture.cs
@@ -1,8 +1,10 @@
-﻿using System.Threading;
+﻿using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
 using LambdaS3FileZipper.Aws;
+using LambdaS3FileZipper.Models;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -17,15 +19,20 @@ namespace LambdaS3FileZipper.Test.Aws
 
 		private string bucket;
 		private string resource;
-		private string file;
-		private CancellationToken regular;
+		private string localFile;
+		private FileResponse fileResponse;
+		private CancellationToken cancellationToken;
 
 		[SetUp]
 		public void SetUp()
 		{
 			bucket = "bucket";
 			resource = "resource";
-			file = "compressed-file";
+			localFile = "compressed-file";
+
+			fileResponse = new FileResponse(localFile, contentStream: new MemoryStream());
+
+			cancellationToken = CancellationToken.None;
 
 			amazonS3 = Substitute.For<IAmazonS3>();
 
@@ -35,11 +42,11 @@ namespace LambdaS3FileZipper.Test.Aws
 		[Test]
 		public async Task Upload_ShouldPutFileInS3()
 		{
-			await client.Upload(bucket, resource, file, regular);
+			await client.Upload(bucket, resource, localFile, cancellationToken);
 
 			await amazonS3.Received().PutObjectAsync(
-				Arg.Is<PutObjectRequest>(request => request.BucketName == bucket && request.Key == resource && request.FilePath == file),
-				regular);
+				Arg.Is<PutObjectRequest>(request => request.BucketName == bucket && request.Key == resource && request.FilePath == localFile),
+				cancellationToken);
 		}
 
 		[Test]
@@ -47,13 +54,33 @@ namespace LambdaS3FileZipper.Test.Aws
 		{
 			var canceled = new CancellationToken(canceled: true);
 
-			Assert.ThrowsAsync<TaskCanceledException>(() => client.Upload(bucket, resource, file, canceled));
+			Assert.ThrowsAsync<TaskCanceledException>(() => client.Upload(bucket, resource, localFile, canceled));
 
 			await amazonS3.DidNotReceive().PutObjectAsync(Arg.Any<PutObjectRequest>(), canceled);
 		}
 
 		[Test]
-		public void GenerateUrl_ShouldGetPresignedUrl()
+		public async Task Upload_WithInMemoryFile_ShouldPutFileInS3()
+		{
+			await client.Upload(bucket, resource, fileResponse, cancellationToken);
+
+			await amazonS3.Received().PutObjectAsync(
+				Arg.Is<PutObjectRequest>(request => request.BucketName == bucket && request.Key == resource && request.InputStream == fileResponse.ContentStream),
+				cancellationToken);
+		}
+
+		[Test]
+		public async Task Upload_WithInMemoryFile_ShouldThrowOnCancellation()
+		{
+			var canceled = new CancellationToken(canceled: true);
+
+			Assert.ThrowsAsync<TaskCanceledException>(() => client.Upload(bucket, resource, fileResponse, canceled));
+
+			await amazonS3.DidNotReceive().PutObjectAsync(Arg.Any<PutObjectRequest>(), canceled);
+		}
+
+		[Test]
+		public void GenerateUrl_ShouldGetPreSignedUrl()
 		{
 			client.GenerateUrl(bucket, resource);
 

--- a/LambdaS3FileZipper.Test/Aws/S3FileUploaderFixture.cs
+++ b/LambdaS3FileZipper.Test/Aws/S3FileUploaderFixture.cs
@@ -1,7 +1,9 @@
-﻿using System.Threading;
+﻿using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.Aws;
 using LambdaS3FileZipper.Interfaces;
+using LambdaS3FileZipper.Models;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -14,15 +16,23 @@ namespace LambdaS3FileZipper.Test.Aws
 
 	    private IAwsS3Client client;
 
-	    private string bucket = "bucket";
-	    private string resource = "resource";
-	    private string compressedFile = "compressed-file";
-		private string url = "s3.com/compressed-file";
-	    private CancellationToken regular = new CancellationToken();
+	    private string bucket;
+	    private string resource;
+	    private string filePath;
+	    private FileResponse fileResponse;
+		private string url;
+		private CancellationToken cancellationToken;
 
 		[SetUp]
 	    public void SetUp()
 		{
+			bucket = "bucket";
+			resource = "resource";
+			filePath = "file";
+			url = "s3.com/file";
+			fileResponse = new FileResponse("file", contentStream: new MemoryStream());
+			cancellationToken = CancellationToken.None;
+
 			client = Substitute.For<IAwsS3Client>();
 			client.GenerateUrl(bucket, resource).Returns(url);
 
@@ -32,15 +42,15 @@ namespace LambdaS3FileZipper.Test.Aws
 	    [Test]
 	    public async Task Upload_ShouldUploadLocalCompressedFile()
 	    {
-		    await uploader.Upload(bucket, resource, compressedFile, regular);
+		    await uploader.Upload(bucket, resource, filePath, cancellationToken);
 
-		    await client.Received().Upload(bucket, resource, compressedFile, regular);
+		    await client.Received().Upload(bucket, resource, filePath, cancellationToken);
 	    }
 
 	    [Test]
 	    public async Task Upload_ShouldGenerateAnUrlForUploadedResource()
 	    {
-		    await uploader.Upload(bucket, resource, compressedFile, regular);
+		    await uploader.Upload(bucket, resource, filePath, cancellationToken);
 
 		    client.Received().GenerateUrl(bucket, resource);
 	    }
@@ -48,7 +58,7 @@ namespace LambdaS3FileZipper.Test.Aws
 	    [Test]
 	    public async Task Upload_ShouldReturnUrl()
 	    {
-		    var generatedUrl = await uploader.Upload(bucket, resource, compressedFile, regular);
+		    var generatedUrl = await uploader.Upload(bucket, resource, filePath, cancellationToken);
 
 			Assert.That(generatedUrl, Is.EqualTo(url));
 	    }
@@ -58,9 +68,43 @@ namespace LambdaS3FileZipper.Test.Aws
 	    {
 			var canceled = new CancellationToken(canceled: true);
 
-		    Assert.ThrowsAsync<TaskCanceledException>(() => uploader.Upload(bucket, resource, compressedFile, canceled));
+		    Assert.ThrowsAsync<TaskCanceledException>(() => uploader.Upload(bucket, resource, filePath, canceled));
 
-		    await client.DidNotReceive().Upload(bucket, resource, compressedFile, canceled);
+		    await client.DidNotReceive().Upload(bucket, resource, filePath, canceled);
+	    }
+
+	    [Test]
+	    public async Task Upload_WithInMemoryFile_ShouldUploadLocalCompressedFile()
+	    {
+		    await uploader.Upload(bucket, resource, fileResponse, cancellationToken);
+
+		    await client.Received().Upload(bucket, resource, fileResponse, cancellationToken);
+	    }
+
+	    [Test]
+	    public async Task Upload_WithInMemoryFile_ShouldGenerateAnUrlForUploadedResource()
+	    {
+		    await uploader.Upload(bucket, resource, fileResponse, cancellationToken);
+
+		    client.Received().GenerateUrl(bucket, resource);
+	    }
+
+	    [Test]
+	    public async Task Upload_WithInMemoryFile_ShouldReturnUrl()
+	    {
+		    var generatedUrl = await uploader.Upload(bucket, resource, fileResponse, cancellationToken);
+
+		    Assert.That(generatedUrl, Is.EqualTo(url));
+	    }
+
+	    [Test]
+	    public async Task Upload_WithInMemoryFile_ShouldThrowExceptionWhenCanceled()
+	    {
+		    cancellationToken = new CancellationToken(canceled: true);
+
+		    Assert.ThrowsAsync<TaskCanceledException>(() => uploader.Upload(bucket, resource, fileResponse, cancellationToken));
+
+		    await client.DidNotReceive().Upload(bucket, resource, fileResponse, cancellationToken);
 	    }
 	}
 }

--- a/LambdaS3FileZipper/Aws/AwsS3Client.cs
+++ b/LambdaS3FileZipper/Aws/AwsS3Client.cs
@@ -92,7 +92,15 @@ namespace LambdaS3FileZipper.Aws
 			await client.PutObjectAsync(request, cancellationToken);
 		}
 
-		public async Task Delete(string bucketName, string resourceName, CancellationToken cancellationToken)
+        public async Task Upload(string bucketName, string resourceName, FileResponse fileResponse, CancellationToken cancellationToken)
+        {
+	        cancellationToken.ThrowIfCancellationRequested();
+
+	        var request = new PutObjectRequest {BucketName = bucketName, Key = resourceName, InputStream = fileResponse.ContentStream};
+	        await client.PutObjectAsync(request, cancellationToken);
+        }
+
+        public async Task Delete(string bucketName, string resourceName, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 

--- a/LambdaS3FileZipper/Aws/S3FileUploader.cs
+++ b/LambdaS3FileZipper/Aws/S3FileUploader.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.Interfaces;
+using LambdaS3FileZipper.Models;
 
 namespace LambdaS3FileZipper.Aws
 {
@@ -14,12 +14,20 @@ namespace LambdaS3FileZipper.Aws
 			this.client = client;
 		}
 
-	    public async Task<string> Upload(string bucket, string fileKey, string compressedFileName, CancellationToken token)
+	    public async Task<string> Upload(string bucket, string fileKey, string compressedFileName, CancellationToken cancellationToken = default)
 	    {
-			token.ThrowIfCancellationRequested();
+			cancellationToken.ThrowIfCancellationRequested();
 
-		    await client.Upload(bucket, fileKey, compressedFileName, token);
+		    await client.Upload(bucket, fileKey, compressedFileName, cancellationToken);
 		    return client.GenerateUrl(bucket, fileKey);
 	    }
-    }
+
+	    public async Task<string> Upload(string bucket, string fileKey, FileResponse fileResponse, CancellationToken cancellationToken = default)
+	    {
+		    cancellationToken.ThrowIfCancellationRequested();
+
+		    await client.Upload(bucket, fileKey, fileResponse, cancellationToken);
+		    return client.GenerateUrl(bucket, fileKey);
+	    }
+	}
 }

--- a/LambdaS3FileZipper/Aws/S3FileUploader.cs
+++ b/LambdaS3FileZipper/Aws/S3FileUploader.cs
@@ -14,12 +14,12 @@ namespace LambdaS3FileZipper.Aws
 			this.client = client;
 		}
 
-	    public async Task<string> Upload(string bucketName, string resourceName, string compressedFileName, CancellationToken token)
+	    public async Task<string> Upload(string bucket, string fileKey, string compressedFileName, CancellationToken token)
 	    {
 			token.ThrowIfCancellationRequested();
 
-		    await client.Upload(bucketName, resourceName, compressedFileName, token);
-		    return client.GenerateUrl(bucketName, resourceName);
+		    await client.Upload(bucket, fileKey, compressedFileName, token);
+		    return client.GenerateUrl(bucket, fileKey);
 	    }
     }
 }

--- a/LambdaS3FileZipper/Interfaces/IAwsS3Client.cs
+++ b/LambdaS3FileZipper/Interfaces/IAwsS3Client.cs
@@ -11,6 +11,7 @@ namespace LambdaS3FileZipper.Interfaces
 	    Task<string> Download(string bucketName, string resource, string destinationPath, CancellationToken cancellationToken);
         Task<FileResponse> Download(string bucketName, string resourceKey, CancellationToken cancellationToken);
 	    Task Upload(string bucketName, string resourceName, string filePath, CancellationToken cancellationToken);
+	    Task Upload(string bucketName, string resourceKey, FileResponse fileResponse, CancellationToken cancellationToken);
 	    Task Delete(string bucketName, string resourceName, CancellationToken cancellationToken);
 	    string GenerateUrl(string bucketName, string resourceName);
     }

--- a/LambdaS3FileZipper/Interfaces/IFileRetriever.cs
+++ b/LambdaS3FileZipper/Interfaces/IFileRetriever.cs
@@ -6,7 +6,34 @@ namespace LambdaS3FileZipper.Interfaces
 {
 	public interface IFileRetriever
 	{
-		Task<string> RetrieveToLocalDirectory(string bucket, string resource, string resourceExpressionPattern = default, CancellationToken cancellationToken = default);
-		Task<FileResponse[]> RetrieveToMemory(string bucket, string fileKey, string resourceExpressionPattern = default, CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Retrieves files in given <c><see cref="bucket"/></c> matching name key <c><see cref="resource"/></c> 
+		/// into a local directory named after <c><see cref="bucket"/></c>'s value.
+		///
+		/// <para>Optional: downloaded files can be filtered based on regular expression defined
+		/// by <c><see cref="resourceExpressionPattern"/></c></para>
+		/// </summary>
+		/// <param name="bucket"></param>
+		/// <param name="resource"></param>
+		/// <param name="resourceExpressionPattern">Optional. Should be a valid regular expression</param>
+		/// <param name="cancellationToken">Optional</param>
+		/// <returns>Local directory path</returns>
+		Task<string> RetrieveToLocalDirectory(
+			string bucket, string resource, string resourceExpressionPattern = default, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Retrieves files in given {<see cref="bucket"/>} matching file key {<see cref="fileKey"/>}
+		/// into memory as a collection of <see cref="FileResponse"/>.
+		///
+		/// <para>Optional: downloaded files can be filtered based on regular expression defined
+		/// by <c><see cref="resourceExpressionPattern"/></c></para>
+		/// </summary>
+		/// <param name="bucket"></param>
+		/// <param name="fileKey"></param>
+		/// <param name="resourceExpressionPattern">Optional. Should be a valid regular expression</param>
+		/// <param name="cancellationToken">Optional</param>
+		/// <returns>Collection of files with their content</returns>
+		Task<FileResponse[]> RetrieveToMemory(
+			string bucket, string fileKey, string resourceExpressionPattern = default, CancellationToken cancellationToken = default);
 	}
 }

--- a/LambdaS3FileZipper/Interfaces/IFileUploader.cs
+++ b/LambdaS3FileZipper/Interfaces/IFileUploader.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using LambdaS3FileZipper.Models;
 
 namespace LambdaS3FileZipper.Interfaces
 {
@@ -15,5 +16,16 @@ namespace LambdaS3FileZipper.Interfaces
 		/// <param name="cancellationToken">Optional</param>
 		/// <returns><c>URL</c> of the file uploaded</returns>
 		Task<string> Upload(string bucket, string fileKey, string localFileName, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Uploads in-memory file <c><see cref="fileResponse"/></c> of type <see cref="FileResponse"/>
+		/// to the given <c><see cref="bucket"/></c> under the name <c><see cref="fileKey"/></c>.
+		/// </summary>
+		/// <param name="bucket"></param>
+		/// <param name="fileKey"></param>
+		/// <param name="fileResponse"></param>
+		/// <param name="cancellationToken">Optional</param>
+		/// <returns><c>URL</c> of the file uploaded</returns>
+		Task<string> Upload(string bucket, string fileKey, FileResponse fileResponse, CancellationToken cancellationToken = default);
 	}
 }

--- a/LambdaS3FileZipper/Interfaces/IFileUploader.cs
+++ b/LambdaS3FileZipper/Interfaces/IFileUploader.cs
@@ -5,7 +5,15 @@ namespace LambdaS3FileZipper.Interfaces
 {
 	public interface IFileUploader
 	{
-		Task<string> Upload(string bucketName, string resourceName, string compressedFileName, CancellationToken token);
-
+		/// <summary>
+		/// Uploads file referenced by <c><see cref="localFileName"/></c> to the given <c><see cref="bucket"/></c>
+		/// under the name <c><see cref="fileKey"/></c>.
+		/// </summary>
+		/// <param name="bucket"></param>
+		/// <param name="fileKey"></param>
+		/// <param name="localFileName"></param>
+		/// <param name="cancellationToken">Optional</param>
+		/// <returns><c>URL</c> of the file uploaded</returns>
+		Task<string> Upload(string bucket, string fileKey, string localFileName, CancellationToken cancellationToken = default);
 	}
 }


### PR DESCRIPTION
#### Background

Due to reports that ZIP requests are running out of space, and the fixed value of AWS Lambda function storage of `512 MB`, we are re-implementing the `aws-lambda-s3-zipper` to store content in memory, which can be scaled up in AWS Lambda up to `5120 MB`.

#### Related Changes
- https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/31 Implement methods for retrieving files from **AWS S3** into memory as `FileResponses` 
- https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/32 Implement way to compress in-memory `FileResponse` streams

#### Solution

The current changes implement methods to upload files to **AWS S3** referenced by a `FileResponse`:

- Updates `AwsS3Client` to accept a `FileResponse` file reference (https://github.com/litmus/aws-lambda-s3-zipper-dotnet/commit/6b254c986f8a4c3c08e36d003ac3fb974f459e2b)
- Updates `S3FileUploader` to accept a `FileResponse`, referencing a file content stream (https://github.com/litmus/aws-lambda-s3-zipper-dotnet/commit/f79eaa2213b9cd00445922456770efc3bb7082d7)