### PR TITLE
Fix FileZipper bug when flat structure is enabled and no files get compressed

### DIFF
--- a/LambdaS3FileZipper.IntegrationTests/FileZipperFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/FileZipperFixture.cs
@@ -48,8 +48,22 @@ namespace LambdaS3FileZipper.IntegrationTests
 			await File.WriteAllTextAsync(textFilePath, "Compress test.");
 
 			zipFilePath = await fileZipper.Compress(sourceDirectoryPath);
+			Debugger.Break();
 
 			FileAssert.Exists(zipFilePath);
+			FileAssert.ZipHasFiles(zipFilePath);
+		}
+
+		[Test]
+		public async Task Compress_WithFlatEnabled_ShouldZipFolder()
+		{
+			await FileTool.CreateTempTextFile(sourceDirectoryPath, "compress.txt", fileContent: "compress");
+
+			zipFilePath = await fileZipper.Compress(sourceDirectoryPath, flat: true);
+			Debugger.Break();
+
+			FileAssert.Exists(zipFilePath);
+			FileAssert.ZipHasFiles(zipFilePath);
 		}
 
 		[Test]

--- a/LambdaS3FileZipper.IntegrationTests/FileZipperFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/FileZipperFixture.cs
@@ -51,7 +51,7 @@ namespace LambdaS3FileZipper.IntegrationTests
 			Debugger.Break();
 
 			FileAssert.Exists(zipFilePath);
-			FileAssert.ZipHasFiles(zipFilePath);
+			FileAssert.ZipHasFiles(zipFilePath, expectedFileCount: 1);
 		}
 
 		[Test]
@@ -59,11 +59,15 @@ namespace LambdaS3FileZipper.IntegrationTests
 		{
 			await FileTool.CreateTempTextFile(sourceDirectoryPath, "compress.txt", fileContent: "compress");
 
+			var subDirectoryPath = Path.Combine(sourceDirectoryPath, Guid.NewGuid().ToString());
+			Directory.CreateDirectory(subDirectoryPath);
+			await FileTool.CreateTempTextFile(subDirectoryPath, "compress-sub.txt", fileContent: "compress-sub");
+
 			zipFilePath = await fileZipper.Compress(sourceDirectoryPath, flat: true);
 			Debugger.Break();
 
 			FileAssert.Exists(zipFilePath);
-			FileAssert.ZipHasFiles(zipFilePath);
+			FileAssert.ZipHasFiles(zipFilePath, expectedFileCount: 2);
 		}
 
 		[Test]

--- a/LambdaS3FileZipper.IntegrationTests/Testing/FileAssert.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Testing/FileAssert.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.IO.Compression;
 using NUnit.Framework;
 
 namespace LambdaS3FileZipper.IntegrationTests.Testing
@@ -24,6 +25,20 @@ namespace LambdaS3FileZipper.IntegrationTests.Testing
 			var file = new FileInfo(filePath);
 			Assert.That(file.Exists, Is.True);
 			Assert.That(file.Length, Is.GreaterThan(0));
+		}
+
+		/// <summary>
+		/// Asserts that the ZIP file at <see cref="filePath"/> exists and is non-empty,
+		/// and has at least one file compressed
+		/// </summary>
+		/// <param name="filePath"></param>
+		public static void ZipHasFiles(string filePath)
+		{
+			HasContent(filePath);
+
+			using var fileStream = File.OpenRead(filePath);
+			using var zipArchive = new ZipArchive(fileStream, ZipArchiveMode.Read);
+			Assert.That(zipArchive.Entries, Is.Not.Empty);
 		}
 	}
 }

--- a/LambdaS3FileZipper.IntegrationTests/Testing/FileAssert.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Testing/FileAssert.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.IO.Compression;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 
 namespace LambdaS3FileZipper.IntegrationTests.Testing
 {
@@ -32,13 +33,21 @@ namespace LambdaS3FileZipper.IntegrationTests.Testing
 		/// and has at least one file compressed
 		/// </summary>
 		/// <param name="filePath"></param>
-		public static void ZipHasFiles(string filePath)
+		/// <param name="expectedFileCount"></param>
+		public static void ZipHasFiles(string filePath, int? expectedFileCount = default)
 		{
 			HasContent(filePath);
 
 			using var fileStream = File.OpenRead(filePath);
 			using var zipArchive = new ZipArchive(fileStream, ZipArchiveMode.Read);
-			Assert.That(zipArchive.Entries, Is.Not.Empty);
+			if (expectedFileCount.HasValue)
+			{
+				Assert.That(zipArchive.Entries.Count, Is.EqualTo(expectedFileCount.Value));
+			}
+			else
+			{
+				Assert.That(zipArchive.Entries, Is.Not.Empty);
+			}
 		}
 	}
 }

--- a/LambdaS3FileZipper/FileZipper.cs
+++ b/LambdaS3FileZipper/FileZipper.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.Extensions;
@@ -66,7 +67,7 @@ namespace LambdaS3FileZipper
 		{
 			using (var zipArchive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
 			{
-				foreach (var file in GetFiles(localDirectory))
+				foreach (var file in GetFilesRecursively(localDirectory))
 				{
 					var zipEntry = zipArchive.CreateEntry(Path.GetFileName(file));
 
@@ -79,17 +80,17 @@ namespace LambdaS3FileZipper
 			}
 		}
 
-		private IEnumerable<string> GetFiles(string directory)
+		private static IEnumerable<string> GetFilesRecursively(string directory)
 		{
-			var files = new List<string>();
-
-			foreach (var dir in Directory.GetDirectories(directory))
+			foreach (var filePath in Directory.GetFiles(directory))
 			{
-				files.AddRange(Directory.GetFiles(dir));
-				files.AddRange(GetFiles(dir));
+				yield return filePath;
 			}
 
-			return files;
+			foreach (var filePath in Directory.GetDirectories(directory).SelectMany(GetFilesRecursively))
+			{
+				yield return filePath;
+			}
 		}
 	}
 }

--- a/LambdaS3FileZipper/FileZipper.cs
+++ b/LambdaS3FileZipper/FileZipper.cs
@@ -65,18 +65,14 @@ namespace LambdaS3FileZipper
 
 		private async Task CreateFlatZip(string localDirectory, string zipPath)
 		{
-			using (var zipArchive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+			using var zipArchive = ZipFile.Open(zipPath, ZipArchiveMode.Create);
+			foreach (var filePath in GetFilesRecursively(localDirectory))
 			{
-				foreach (var file in GetFilesRecursively(localDirectory))
-				{
-					var zipEntry = zipArchive.CreateEntry(Path.GetFileName(file));
+				var zipEntry = zipArchive.CreateEntry(Path.GetFileName(filePath));
 
-					using(var fileReader = File.OpenRead(file))
-					using (var zipStream = zipEntry.Open())
-					{
-						await fileReader.CopyToAsync(zipStream);
-					}
-				}
+				using var fileReader = File.OpenRead(filePath);
+				using var zipStream = zipEntry.Open();
+				await fileReader.CopyToAsync(zipStream);
 			}
 		}
 


### PR DESCRIPTION
#### Background

While testing the current implementation, I found a bug on `FileZipper` when `flat = true` where no files will be compressed when a directory contains no sub-directories.

#### Solution

Update `FileZipper` when `flat = true` to iterate over current directory's files _first_, then recursively enumerate each sub-directory (https://github.com/litmus/aws-lambda-s3-zipper-dotnet/commit/01755675fc15dce1d2a8f6e21d772e2c98a231a2).

Expanded integration tests for `FileZipper` to validate a ZIP file content and number of entries (https://github.com/litmus/aws-lambda-s3-zipper-dotnet/commit/018d01c2057e18f7122f1b6eef415f3c85355dea).