### PR TITLE
Update FileZipperService to use in-memory implementation

### DIFF
--- a/LambdaS3FileZipper.App/InternalLambdaContext.cs
+++ b/LambdaS3FileZipper.App/InternalLambdaContext.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Amazon.Lambda.Core;
+
+namespace LambdaS3FileZipper.App
+{
+	internal class InternalLambdaContext : ILambdaContext
+	{
+		public InternalLambdaContext(string awsRequestId)
+		{
+			AwsRequestId = awsRequestId;
+		}
+
+		public string AwsRequestId { get; }
+		public IClientContext ClientContext { get; }
+		public string FunctionName { get; }
+		public string FunctionVersion { get; }
+		public ICognitoIdentity Identity { get; }
+		public string InvokedFunctionArn { get; }
+		public ILambdaLogger Logger { get; }
+		public string LogGroupName { get; }
+		public string LogStreamName { get; }
+		public int MemoryLimitInMB { get; }
+		public TimeSpan RemainingTime { get; }
+	}
+}

--- a/LambdaS3FileZipper.App/LambdaS3FileZipper.App.csproj
+++ b/LambdaS3FileZipper.App/LambdaS3FileZipper.App.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;LIBLOG_PUBLIC</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LibLog" Version="5.0.0" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LambdaS3FileZipper\LambdaS3FileZipper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LambdaS3FileZipper.App/LambdaS3FileZipper.App.csproj
+++ b/LambdaS3FileZipper.App/LambdaS3FileZipper.App.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/LambdaS3FileZipper.App/Program.cs
+++ b/LambdaS3FileZipper.App/Program.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.S3;
+using LambdaS3FileZipper.Aws;
+using LambdaS3FileZipper.Models;
+using Serilog;
+
+namespace LambdaS3FileZipper.App
+{
+    internal class Program
+    {
+		internal static async Task Main()
+        {
+			// Enable Serilog Console logging
+			Log.Logger = new LoggerConfiguration().MinimumLevel.Verbose().WriteTo.Console().CreateLogger();
+
+			// Todo: Fill in credential, request details
+			var accessKey = "access-key";
+			var secretKey = "secret-key";
+			var endpoint = RegionEndpoint.USEast1;
+			var requestGuid = "guid";
+			var request = new Request
+			{
+				OriginBucketName = "origin-bucket",
+				OriginResourceName = $"{requestGuid}/results",
+				DestinationBucketName = "target-bucket",
+				DestinationResourceName = $"{requestGuid}.zip",
+				OriginResourceExpressionPattern = @".*.png$",
+			};
+
+			var client = new AwsS3Client(new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey), endpoint));
+			var service = new Service(new S3FileRetriever(client), new FileZipper(), new S3FileUploader(client));
+	        var handler = new Handler(service);
+			var context = new InternalLambdaContext(awsRequestId: requestGuid);
+
+			await handler.Handle(request, context);
+		}
+    }
+}

--- a/LambdaS3FileZipper.IntegrationTests/LambdaS3FileZipper.IntegrationTests.csproj
+++ b/LambdaS3FileZipper.IntegrationTests/LambdaS3FileZipper.IntegrationTests.csproj
@@ -1,8 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netcoreapp2.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<LangVersion>8.0</LangVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+	  <DefineConstants>TRACE;LIBLOG_PUBLIC</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="LibLog" Version="5.0.0" />

--- a/LambdaS3FileZipper.sln
+++ b/LambdaS3FileZipper.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LambdaS3FileZipper.App", "LambdaS3FileZipper.App\LambdaS3FileZipper.App.csproj", "{6F6BC648-2472-4E45-8025-D849120670CD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{26165F86-E52F-41BB-97B0-1B24979CB826}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{26165F86-E52F-41BB-97B0-1B24979CB826}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{26165F86-E52F-41BB-97B0-1B24979CB826}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F6BC648-2472-4E45-8025-D849120670CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F6BC648-2472-4E45-8025-D849120670CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F6BC648-2472-4E45-8025-D849120670CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F6BC648-2472-4E45-8025-D849120670CD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LambdaS3FileZipper/LambdaS3FileZipper.csproj
+++ b/LambdaS3FileZipper/LambdaS3FileZipper.csproj
@@ -14,7 +14,7 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;LIBLOG_PUBLIC</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.3.18.5" />


### PR DESCRIPTION
#### Background

Due to reports that ZIP requests are running out of space, and the fixed value of AWS Lambda function storage of `512 MB`, we are re-implementing the `aws-lambda-s3-zipper` to store content in memory, which can be scaled up in AWS Lambda up to `5120 MB`.

#### Related Changes
- https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/31 Implement methods for retrieving files from **AWS S3** into memory as `FileResponses` 
- https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/32 Implement way to compress in-memory `FileResponse` streams
- https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/33 Implement methods to upload files to **AWS S3** using `FileResponse`

#### Solution

These final changes update the `Service` implementation to use in-memory operations (https://github.com/litmus/aws-lambda-s3-zipper-dotnet/commit/a882f9f44f019e01ee44986496c7365394d14a2f) previously built.

The changes also include a `Console`-based application to test end-to-end the entire **Lambda** function (with better reliability and performance than IDE testing frameworks).