### PR TITLE
Support flat option for in-memory operation

### DIFF
--- a/LambdaS3FileZipper.IntegrationTests/FileZipperFixture.cs
+++ b/LambdaS3FileZipper.IntegrationTests/FileZipperFixture.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LambdaS3FileZipper.IntegrationTests.Extensions;
+using LambdaS3FileZipper.IntegrationTests.Logging;
 using LambdaS3FileZipper.IntegrationTests.Testing;
+using LambdaS3FileZipper.Models;
 using NUnit.Framework;
 using FileAssert = LambdaS3FileZipper.IntegrationTests.Testing.FileAssert;
 
@@ -14,24 +17,33 @@ namespace LambdaS3FileZipper.IntegrationTests
 	[TestFixture]
 	public class FileZipperFixture
 	{
+		private ILog log;
+
 		private FileZipper fileZipper;
 
 		private string zipFilePath;
 		private string sourceDirectoryName;
 		private string sourceDirectoryPath;
-
 		private CancellationToken cancellationToken;
+
+		[OneTimeSetUp]
+		public void OneTimeSetUp()
+		{
+			ConsoleLog.EnableSerilog();
+
+			log = LogProvider.GetCurrentClassLogger();
+		}
 
 		[SetUp]
 		public void SetUp()
 		{
 			sourceDirectoryName = Guid.NewGuid().ToString();
 			sourceDirectoryPath = Path.Combine(Path.GetTempPath(), sourceDirectoryName);
+			cancellationToken = CancellationToken.None;
+
 			Directory.CreateDirectory(sourceDirectoryPath);
 
 			fileZipper = new FileZipper();
-
-			cancellationToken = CancellationToken.None;
 		}
 
 		[TearDown]
@@ -74,20 +86,48 @@ namespace LambdaS3FileZipper.IntegrationTests
 		public async Task Compress_ShouldZipFilesInMemory()
 		{
 			var zipFileKey = $"{sourceDirectoryName}.zip";
-			zipFilePath = Path.Combine(Path.GetTempPath(), zipFileKey);
+			var subDirectoryName = Guid.NewGuid().ToString();
+			var fileResponses = await CreateTempTextFiles(subDirectoryName, "text-file-0.txt", "text-file-1.txt");
 
-			var tempFileNames = new[] {"text-file-0.txt", "text-file-1.txt"};
+			var zipFileResponse = await fileZipper.Compress(zipFileKey, fileResponses, cancellationToken: cancellationToken);
+
+			zipFilePath = Path.Combine(Path.GetTempPath(), zipFileKey);
+			await zipFileResponse.WriteTo(zipFilePath);
+			log.Debug("Wrote ZIP files to {ZipFilePath}", zipFilePath);
+			Debugger.Break();
+
+			FileAssert.ZipHasFiles(zipFilePath, expectedFileCount: 2);
+			FileAssert.ZipHasFilesWithName(zipFilePath, entryFileName: $"{subDirectoryName}/text-file-0.txt");
+		}
+
+		[Test]
+		public async Task Compress_WithFlatEnabled_ShouldZipFilesInMemory()
+		{
+			var zipFileKey = $"{sourceDirectoryName}.zip";
+			var subDirectoryName = Guid.NewGuid().ToString();
+			var fileResponses = await CreateTempTextFiles(subDirectoryName, "text-file-0.txt", "text-file-1.txt");
+
+			var zipFileResponse = await fileZipper.Compress(zipFileKey, fileResponses, flat: true, cancellationToken);
+
+			zipFilePath = Path.Combine(Path.GetTempPath(), zipFileKey);
+			await zipFileResponse.WriteTo(zipFilePath);
+			log.Debug("Wrote ZIP files to {ZipFilePath}", zipFilePath);
+			Debugger.Break();
+
+			FileAssert.ZipHasFiles(zipFilePath, expectedFileCount: 2);
+			FileAssert.ZipHasFilesWithName(zipFilePath, entryFileName: "text-file-0.txt");
+		}
+
+		private async Task<IEnumerable<FileResponse>> CreateTempTextFiles(string subDirectoryName, params string[] fileNames)
+		{
+			// Create sub-directory to validate flat structure of resulting compressed file
+			FileTool.CreateDirectoryIn(sourceDirectoryPath, subDirectoryName);
+
+			var tempFileNames = fileNames.Select(fileName => $"{subDirectoryName}/{fileName}");
 			var fileResponses = await Task.WhenAll(tempFileNames
 				.Select(fileName => FileTool.CreateTempTextFile(sourceDirectoryPath, fileName, fileContent: fileName))
 				.ToArray());
-
-			var zipFileResponse = await fileZipper.Compress(zipFileKey, fileResponses, cancellationToken);
-
-			await zipFileResponse.WriteTo(zipFilePath);
-			Console.WriteLine("Created zipFilePath at {0}", zipFilePath);
-			Debugger.Break();
-
-			FileAssert.HasContent(zipFilePath);
+			return fileResponses;
 		}
 	}
 }

--- a/LambdaS3FileZipper.IntegrationTests/LambdaS3FileZipper.IntegrationTests.csproj
+++ b/LambdaS3FileZipper.IntegrationTests/LambdaS3FileZipper.IntegrationTests.csproj
@@ -13,6 +13,7 @@
 		<PackageReference Include="nunit" Version="3.10.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\..\aws-lambda-s3-zipper-dotnet\LambdaS3FileZipper\LambdaS3FileZipper.csproj" />

--- a/LambdaS3FileZipper.IntegrationTests/Testing/ConsoleLog.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Testing/ConsoleLog.cs
@@ -1,0 +1,15 @@
+﻿using Serilog;
+
+namespace LambdaS3FileZipper.IntegrationTests.Testing
+{
+	public static class ConsoleLog
+	{
+		/// <summary>
+		/// Enables Serilog logging to the Console
+		/// </summary>
+		public static void EnableSerilog()
+		{
+			Log.Logger = new LoggerConfiguration().MinimumLevel.Verbose().WriteTo.Console().CreateLogger();
+		}
+	}
+}

--- a/LambdaS3FileZipper.IntegrationTests/Testing/FileAssert.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Testing/FileAssert.cs
@@ -1,12 +1,15 @@
 ﻿using System.IO;
 using System.IO.Compression;
+using System.Linq;
+using LambdaS3FileZipper.IntegrationTests.Logging;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace LambdaS3FileZipper.IntegrationTests.Testing
 {
 	public static class FileAssert
 	{
+		private static readonly ILog Log = LogProvider.GetCurrentClassLogger();
+
 		/// <summary>
 		/// Asserts that file at <see cref="filePath"/> exists
 		/// </summary>
@@ -48,6 +51,26 @@ namespace LambdaS3FileZipper.IntegrationTests.Testing
 			{
 				Assert.That(zipArchive.Entries, Is.Not.Empty);
 			}
+		}
+
+		/// <summary>
+		/// Asserts that the ZIP file at <see cref="filePath"/> exists and is non-empty,
+		/// and has the provided entry file name
+		/// </summary>
+		/// <param name="filePath"></param>
+		/// <param name="entryFileName"></param>
+		public static void ZipHasFilesWithName(string filePath, string entryFileName)
+		{
+			HasContent(filePath);
+
+			using var fileStream = File.OpenRead(filePath);
+			using var zipArchive = new ZipArchive(fileStream, ZipArchiveMode.Read);
+			foreach (var entry in zipArchive.Entries)
+			{
+				Log.Info("Found compressed file entry {EntryFullName}", entry.FullName);
+			}
+
+			Assert.That(zipArchive.Entries.Any(entry => entry.FullName == entryFileName), Is.True);
 		}
 	}
 }

--- a/LambdaS3FileZipper.IntegrationTests/Testing/FileTool.cs
+++ b/LambdaS3FileZipper.IntegrationTests/Testing/FileTool.cs
@@ -34,5 +34,8 @@ namespace LambdaS3FileZipper.IntegrationTests.Testing
 			using var fileStream = File.OpenRead(filePath);
 			return new FileResponse(resourceKey: fileKey, contentStream: await fileStream.CopyStreamOntoMemory(cancellationToken));
 		}
+
+		public static string CreateDirectoryIn(string parentDirectoryPath, string directoryName) =>
+			Directory.CreateDirectory(Path.Combine(parentDirectoryPath, directoryName)).FullName;
 	}
 }

--- a/LambdaS3FileZipper.Test/LambdaS3FileZipper.Test.csproj
+++ b/LambdaS3FileZipper.Test/LambdaS3FileZipper.Test.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LambdaS3FileZipper\LambdaS3FileZipper.csproj" />

--- a/LambdaS3FileZipper.Test/ServiceFixture.cs
+++ b/LambdaS3FileZipper.Test/ServiceFixture.cs
@@ -18,6 +18,7 @@ namespace LambdaS3FileZipper.Test
 		private Request request;
 		private FileResponse[] files;
 		private string compressedFileKey;
+		private bool flatZipFile;
 		private FileResponse compressedFile;
 		private string url;
 		private CancellationToken cancellationToken;
@@ -27,7 +28,9 @@ namespace LambdaS3FileZipper.Test
 		{
 			compressedFileKey = "compressed-file";
 
-			request = new Request("origin-bucket", "origin-resource", "destination-bucket", compressedFileKey, flatZipFile: true);
+			flatZipFile = true;
+
+			request = new Request("origin-bucket", "origin-resource", "destination-bucket", compressedFileKey, flatZipFile);
 
 			files = new []
 			{
@@ -47,7 +50,7 @@ namespace LambdaS3FileZipper.Test
 			fileRetriever.RetrieveToMemory(request.OriginBucketName, request.OriginResourceName, Arg.Any<string>(), cancellationToken).Returns(files);
 
 			fileZipper = Substitute.For<IFileZipper>();
-			fileZipper.Compress(compressedFileKey, files, cancellationToken).Returns(compressedFile);
+			fileZipper.Compress(compressedFileKey, files, flatZipFile, cancellationToken).Returns(compressedFile);
 
 			fileUploader = Substitute.For<IFileUploader>();
 			fileUploader.Upload("destination-bucket", compressedFileKey, compressedFile, cancellationToken).Returns(url);
@@ -76,7 +79,7 @@ namespace LambdaS3FileZipper.Test
 		{
 			await service.Process(request, cancellationToken);
 
-			await fileZipper.Received().Compress(compressedFileKey, files, cancellationToken);
+			await fileZipper.Received().Compress(compressedFileKey, files, flatZipFile, cancellationToken);
 		}
 
 		[Test]

--- a/LambdaS3FileZipper/FileZipper.cs
+++ b/LambdaS3FileZipper/FileZipper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -48,7 +49,11 @@ namespace LambdaS3FileZipper
 			return zipPath;
 		}
 
-		public async Task<FileResponse> Compress(string zipFileKey, IEnumerable<FileResponse> filesResponses, CancellationToken cancellationToken)
+		public async Task<FileResponse> Compress(
+			string zipFileKey,
+			IEnumerable<FileResponse> filesResponses,
+			bool flat = false,
+			CancellationToken cancellationToken = default)
 		{
 			var zipMemoryStream = new MemoryStream();
 
@@ -65,9 +70,10 @@ namespace LambdaS3FileZipper
 				foreach (var fileResponse in filesResponses)
 				{
 					var stopwatch = Stopwatch.StartNew();
-					var zipEntry = zipArchive.CreateEntry(fileResponse.ResourceKey);
+					var entryName = flat ? Path.GetFileName(fileResponse.ResourceKey) : fileResponse.ResourceKey;
+					var entry = zipArchive.CreateEntry(entryName);
 
-					using var zipEntryStream = zipEntry.Open();
+					using var zipEntryStream = entry.Open();
 					using var fileContentStream = fileResponse.ContentStream;
 					await fileContentStream.CopyToAsync(zipEntryStream, 4096, cancellationToken);
 

--- a/LambdaS3FileZipper/Interfaces/IFileZipper.cs
+++ b/LambdaS3FileZipper/Interfaces/IFileZipper.cs
@@ -8,6 +8,11 @@ namespace LambdaS3FileZipper.Interfaces
 	public interface IFileZipper
 	{
 		Task<string> Compress(string localDirectory, bool flat);
-		Task<FileResponse> Compress(string zipFileKey, IEnumerable<FileResponse> filesResponses, CancellationToken cancellationToken);
+
+		Task<FileResponse> Compress(
+			string zipFileKey,
+			IEnumerable<FileResponse> filesResponses,
+			bool flat = false,
+			CancellationToken cancellationToken = default);
 	}
 }

--- a/LambdaS3FileZipper/Service.cs
+++ b/LambdaS3FileZipper/Service.cs
@@ -31,7 +31,7 @@ namespace LambdaS3FileZipper
 		    log.Debug("Retrieved files from {Bucket}:{Resource} | {Time}ms", request.OriginBucketName, request.OriginResourceName, stopwatch.ElapsedMilliseconds);
 
 			stopwatch.Restart();
-		    var compressedFile = await fileZipper.Compress(request.DestinationResourceName, files, cancellationToken);
+		    var compressedFile = await fileZipper.Compress(request.DestinationResourceName, files, request.FlatZipFile, cancellationToken);
 		    log.Debug("Compressed files to {CompressedFileName} | {Time}ms", compressedFile.ResourceKey, stopwatch.ElapsedMilliseconds);
 
 			stopwatch.Restart();


### PR DESCRIPTION
#### Background

Due to reports that ZIP requests are running out of space, and the fixed value of AWS Lambda function storage of `512 MB`, we are re-implementing the `aws-lambda-s3-zipper` to store content in memory, which can be scaled up in AWS Lambda up to `5120 MB`.

#### Related Changes
- https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/31 Implement methods for retrieving files from **AWS S3** into memory as `FileResponses` 
- https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/32 Implement way to compress in-memory `FileResponse` streams
- https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/33 Implement methods to upload files to **AWS S3** using `FileResponse`
- https://github.com/litmus/aws-lambda-s3-zipper-dotnet/pull/35 Update `FileZipperService` to use in-memory implementation

#### Solution

These changes add support for compressing files in a _flat_ structure (i.e. ignoring subdirectories) for the in-memory implementation, or, in other words, when `request.FlatZipFile => true` (https://github.com/litmus/aws-lambda-s3-zipper-dotnet/commit/055ac2cfe1a8045702d091d722f3653bc82d1e6a). Including as well updates to integration tests to validate results for each case.

Changes also include adding a logging implementation package (`Serilog`) to both testing projects to help in testing and debugging (https://github.com/litmus/aws-lambda-s3-zipper-dotnet/commit/169f11f7c0055682bc846be8704dc563c508dfdc).