### PR TITLE
Update LambdaS3FileZipper applications to .NET Core 3.1

### DIFF
--- a/LambdaS3FileZipper.App/LambdaS3FileZipper.App.csproj
+++ b/LambdaS3FileZipper.App/LambdaS3FileZipper.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+	<TargetFramework>netcoreapp3.1</TargetFramework>
 	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/LambdaS3FileZipper.IntegrationTests/LambdaS3FileZipper.IntegrationTests.csproj
+++ b/LambdaS3FileZipper.IntegrationTests/LambdaS3FileZipper.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>

--- a/LambdaS3FileZipper.Test/LambdaS3FileZipper.Test.csproj
+++ b/LambdaS3FileZipper.Test/LambdaS3FileZipper.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	<TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/LambdaS3FileZipper/LambdaS3FileZipper.csproj
+++ b/LambdaS3FileZipper/LambdaS3FileZipper.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Litmus</Company>

--- a/LambdaS3FileZipper/LambdaS3FileZipper.csproj
+++ b/LambdaS3FileZipper/LambdaS3FileZipper.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Litmus</Company>
     <PackageLicenseUrl>https://github.com/litmus/aws-lambda-s3-zipper-dotnet/blob/master/LICENSE</PackageLicenseUrl>
@@ -11,7 +12,6 @@
     <FileVersion>1.0.1.0</FileVersion>
     <Version Condition="'$(VersionSuffix)' != ''">1.0.1.$(VersionSuffix)</Version>
     <DefineConstants>LIBLOG_PORTABLE</DefineConstants>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;LIBLOG_PUBLIC</DefineConstants>


### PR DESCRIPTION
#### Background

**.NET Core** versions 2.0, 2.2 [are EOL within a year](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).

#### Solution

Update `LambdaS3FileZipper` solution to **.NET Standard** 2.1, **.NET Core** 3.1